### PR TITLE
SQL investment success update now based on change.

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -154,7 +154,7 @@ def main():
             sess.query(Investment).\
                 filter(Investment.id == investment.id).\
                 update({
-                    Investment.success: factor > 1,
+                    Investment.success: change > 0,
                     Investment.done: True
                 }, synchronize_session=False)
             sess.commit()


### PR DESCRIPTION
Just noticed that the database update for investment success/failure was still being done based on the factor  rather than the change in balance, which is more robust to rounding effects from converting to int. (**See**: [#58](https://github.com/MemeInvestor/memeinvestor_bot/pull/58))