### PR TITLE
Fixed !broke command when user has active trades

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -207,8 +207,9 @@ class CommentWorker():
         active = sess.query(
             func.count(Investment.id)
         ).filter(Investment.done).filter(Investment.name == investor.name).scalar()
+
         if active:
-            comment.reply_wrap(message.modify_broke_active(active))
+            return comment.reply_wrap(message.modify_broke_active(active))
 
         # Indeed, broke
         sess.query(Investor).filter(Investor.name == investor.name).update({


### PR DESCRIPTION
Currently, there's a bug where if you call !broke while you have active trades, the bot will inform you about the active trades **but also** let you go broke (it shouldn't).

Here's an example case in the wild: https://www.reddit.com/r/MemeEconomy/comments/8pkhbn/i_made_a_format_is_it_worth_buying/e0cb5o3/

This PR fixes that bug.