### PR TITLE
Skip stickied posts. Fixes #90

### DIFF
--- a/src/submitter.py
+++ b/src/submitter.py
@@ -1,4 +1,4 @@
-[B]import time
+import time
 import logging
 
 import praw

--- a/src/submitter.py
+++ b/src/submitter.py
@@ -1,4 +1,4 @@
-import time
+[B]import time
 import logging
 
 import praw
@@ -22,6 +22,12 @@ def main():
     while True:
         try:
             for submission in reddit.subreddit('+'.join(config.subreddits)).stream.submissions(skip_existing=True):
+
+                # This one solves #90
+                # We don't need to post a sticky on stickied posts
+                if submission.stickied:
+                    continue
+
                 logging.info("New submission: %s" % submission)
                 submission.reply_wrap(message.invest_place_here).\
                     mod.distinguish(how='yes', sticky=True)


### PR DESCRIPTION
We don't need ot post a sticky on stickied posts as they are not memes.
This one fixed #90