### PR TITLE
Pin the mariadb image version to 10.2.15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
           - ${VOLUME_ROOT}/caddy/data:/root/.caddy
 
     mysql:
-        image: mariadb
+        image: mariadb:10.2.15
         env_file: .env
         restart: unless-stopped
         volumes:


### PR DESCRIPTION
They changed the 'latest' tag to 10.3.7 recently, and trying to restore
a 10.2.15 dump onto a 10.3.7 instance is a pain, so let's just keep
using the version that dzervas started with.