### PR TITLE
Save an API call by removing call to .parent()

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -75,14 +75,6 @@ class CommentWorker():
         if comment.is_root:
             return
 
-        # Ignore comments without a parent (deleted)
-        if not comment.parent():
-            return
-
-        # Ignore comments not replying to this bot
-        if comment.parent().author.name != config.username:
-            return
-
         # Ignore comments without an author (deleted)
         if not comment.author:
             return


### PR DESCRIPTION
Partially addresses #87.

Since the bot is iterating through its inbox, we already know every
processed comment is going to be a reply to the bot. So we can save a
whole API call per request if we remove this check. This should improve
our throughput.