### PR TITLE
Make website deployable in development environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,10 @@
 ###############################################################################
 
 # For development:
-#BOT_DRY_RUN=1
+BOT_DRY_RUN=1
 
 # For production:
-BOT_DRY_RUN=0
+#BOT_DRY_RUN=0
 
 ###############################################################################
 # Configure Reddit access. See the guide on

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,19 @@
-# Config for bot behavior. Leave this as-is unless
-# you're setting up the bot for production.
+###############################################################################
+# Configure bot behavior. This determines whether the bot will actually try to
+# post to Reddit.
+###############################################################################
 
-BOT_DRY_RUN=1
+# For development:
+#BOT_DRY_RUN=1
 
-# Config to enable praw to access Reddit. See
+# For production:
+BOT_DRY_RUN=0
+
+###############################################################################
+# Configure Reddit access. See the guide on
 # praw.readthedocs.io/en/latest/getting_started/quick_start.html
 # for details on generating your own bot credentials.
+###############################################################################
 
 BOT_CLIENT_ID=
 BOT_CLIENT_SECRET=
@@ -13,13 +21,30 @@ BOT_USER_AGENT=
 BOT_USERNAME=
 BOT_PASSWORD=
 
-# If the bot is accessing Reddit, this determines which
-# subreddit it should monitor.
+###############################################################################
+# Configure which subreddit the bot should watch.
+###############################################################################
 
-BOT_SUBREDDIT=memeeconomy
+# For development:
+BOT_SUBREDDIT=MemeInvestor_test
 
-# Config for the MySQL host and clients. You should be
-# able to leave this unchanged.
+# For production:
+#BOT_SUBREDDIT=MemeEconomy
+
+###############################################################################
+# Configure where Caddy will host the website.
+###############################################################################
+
+# For development:
+CADDY_WEB_ADDRESS=localhost
+
+# For production:
+#CADDY_WEB_ADDRESS=memes.market
+
+###############################################################################
+# Configure MySQL database access. You can leave this as-is. The database is
+# not accessible from the public internet.
+###############################################################################
 
 MYSQL_USER=mysql
 MYSQL_PASSWORD=strongpass!word
@@ -27,7 +52,3 @@ MYSQL_HOST=mysql
 MYSQL_PORT=3306
 MYSQL_DATABASE=mysql
 MYSQL_RANDOM_ROOT_PASSWORD=yes
-
-# Config for determining where http and db files are stored.
-
-VOLUME_ROOT=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:alpine
 
-RUN apk add --update --no-cache mariadb-dev g++
+RUN apk add --update --no-cache \
+    g++ \
+    mariadb-dev
 
 RUN adduser -D user
 USER user

--- a/README.md
+++ b/README.md
@@ -108,15 +108,20 @@ cp .env.example .env
 nano .env
 ```
 
-After filling out the details, save and exit. You're done with configuration.
+Follow the instructions in .env to configure your test deployment, save the file, and exit. You're
+done with configuration.
 
 ### Deployment
 
-From the root of the project directory, use `docker-compose up` to build and launch the various components
-of the bot, including an empty database of investor accounts, the agents that monitor Reddit for new
-submissions and commands, and the informational website.
+From the root of the project directory, use `docker-compose build` followed by `docker-compose up -d`
+to build and launch the various components of the bot, including an empty database of investor
+accounts, the agents that monitor Reddit for new submissions and commands, and the informational
+website.
 
-It is time to make a fortune!
+You should be able to view the website at http://localhost:2015. By default the stats will be
+boring (no investors and no investments) but you can interact with your test bot on Reddit to
+populate the database, or you can manually set up investor accounts by interacting with the
+database directly via Python code or a database manager like `adminer`.
 
 ## Authors
 
@@ -124,7 +129,7 @@ It is time to make a fortune!
  - *Dimitris Zervas* - Main back-end developer. MySQL, Docker, API and overall support - [dzervas](https://github.com/dzervas)
  - *jimbobur* - Our maths guy. Can make really pretty graphs - [jimbobur](https://github.com/jimbobur)
  - *Alberto Ventafridda* - Main front-end and web developer - [robalb](https://github.com/robalb)
- - *rickles42* - Heavy outside contributor - [rickles42](https://github.com/rickles42)
+ - *rickles42* - Back-end and infrastructure developer - [rickles42](https://github.com/rickles42)
  - *TwinProduction* - Heavy outside contributor - [TwinProduction](https://github.com/TwinProduction)
  - *ggppjj* - Minor fixes - [ggppjj](https://github.com/ggppjj)
 

--- a/docker-compose.override.yml.prod
+++ b/docker-compose.override.yml.prod
@@ -1,0 +1,23 @@
+version: '3'
+
+# To run the official bot in production, rename this file to
+# 'docker-compose.override.yml' and Docker will automatically merge it with
+# 'docker-compose.yml' to include the following deployment changes. You can
+# leave this file alone if you're just running the bot locally for testing.
+
+services:
+    # When running in production, map the real HTTP/HTTPS ports and map
+    # the folder where Caddy will save private keys, so they're automatically
+    # saved and don't have to be re-generated with every launch.
+    http:
+        ports:
+          - 80:80
+          - 443:443
+        volumes:
+          - /data/memeinvestor/caddy/data:/root/.caddy
+
+    # When running in production, map the database files onto the host so they
+    # doesn't get lost when we use 'docker-compose down'.
+    mysql:
+        volumes:
+          - /data/memeinvestor/mysql:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,21 +35,14 @@ services:
         build:
             context: .
             dockerfile: docker/Dockerfile-caddy
+        env_file: .env
         restart: unless-stopped
         ports:
-          - 80:80
-          - 443:443
+          - 2015:2015
         depends_on:
           - api
-        volumes:
-          - ./docs:/static
-          - ${VOLUME_ROOT}/caddy/config:/caddy
-          - ${VOLUME_ROOT}/caddy/data:/root/.caddy
 
     mysql:
         image: mariadb:10.2.15
         env_file: .env
         restart: unless-stopped
-        volumes:
-          - ${VOLUME_ROOT}/mysql:/var/lib/mysql
-          - ${VOLUME_ROOT}/my.cnf:/etc/mysql/my.cnf

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,0 +1,10 @@
+{$CADDY_WEB_ADDRESS} {
+	root /static
+	proxy /api api:5000 {
+		without /api
+		transparent
+	}
+
+	log / stdout
+	errors stdout
+}

--- a/docker/Dockerfile-caddy
+++ b/docker/Dockerfile-caddy
@@ -4,13 +4,13 @@ RUN apk add --update --no-cache \
     bash \
     curl
 
-RUN mkdir /caddy
-
 RUN curl https://getcaddy.com | bash -s personal http.cors
 
 WORKDIR /caddy
 
+COPY ./docker/Caddyfile /caddy
+COPY ./docs /static
+
 EXPOSE 80 443 2015
-VOLUME [ "/caddy" ]
 
 CMD [ "caddy" ]

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -2,9 +2,9 @@
 let jsonApi = (function(){
    let options = {
       method: "GET",
-      url: "https://memes.market/api",
+      url: "/api",
+      //url: "https://memes.market/api",
       //url: "http://localhost/memeinvestor_bot/docs/testApiData.json",
-      //url: "/api",
    }
    function makeRequest (param, options) {
       


### PR DESCRIPTION
Supports issue #53. Summary of changes:

* Add the Caddyfile @dzervas made to the repo.

* Update `http` so that the website source code is part of the image instead of mapped from the host system. Updating the website will now be done by re-building the `http` container and starting the new one.

* Add `docker-compose.override.yml.prod` which, when renamed to `docker-compose.override.yml` will add extra configurations to our Compose file to support the production (official) deployment. The normal deployment (i.e. without the override file merged in) is for test/development.

* Tweaked `main.js` to use a relative path `/api`. This doesn't affect the official deployment, but makes it so a local deployment will point to the local deployment of the `api` service instead of the official one.

* Updated README and .env.example