### PR TITLE
Stream comment replies instead of querying inbox

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -267,7 +267,8 @@ def main():
     while not killhandler.killed:
         try:
             # Iterate over the latest comment replies in inbox
-            for comment in reddit.inbox.unread(limit=None):
+            reply_function = reddit.inbox.comment_replies
+            for comment in praw.models.util.stream_generator(reply_function, skip_existing=True):
                 # Measure how long since we finished the last loop iteration
                 duration = stopwatch.measure()
                 logging.info(f"Comment {comment}:")


### PR DESCRIPTION
Addresses #121 and #122.

Using inbox.unread() results in unnecessarily many Reddit API calls, and
also returns mentions, which we don't want to process. Changing to a
stream generator fixes the first issue, and building that stream
generator from the comment_replies function fixes the second issue.