### PR TITLE
Add timing and API call logging to calculator.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -273,7 +273,7 @@ def main():
             for comment in praw.models.util.stream_generator(reply_function, skip_existing=True):
                 # Measure how long since we finished the last loop iteration
                 duration = stopwatch.measure()
-                logging.info(f"Comment {comment}:")
+                logging.info(f"New comment {comment}:")
                 logging.info(f" -- retrieved in {duration:5.2f}s")
 
                 # Process the comment

--- a/src/submitter.py
+++ b/src/submitter.py
@@ -30,7 +30,7 @@ def main():
                 if submission.stickied:
                     continue
 
-                logging.info("New submission: %s" % submission)
+                logging.info(f"New submission: {submission}")
 
                 bot_reply = submission.reply_wrap(message.invest_place_here)
 


### PR DESCRIPTION
Adds timing and API logging to `calculator.py`.

In the process of making this change, I learned a couple things:

* A typical matured investment results in 3 calls to the Reddit API: (1) when reading the upvote count of the submission, (2) when retrieving the body of the bot's prior response, and (3) when posting the edit to that response. It's a bit difficult to tell from looking at the code itself, because PRAW uses "lazy" evaluation (returns placeholders and doesn't populate them until you actually read their values).

* That means we could probably save an API call if we avoided (2) and just rewrote the post entirely when we edit it.

* The check for deleted comments isn't doing anything. PRAW always returns a placeholder that passes the test, and never throws an exception there. We could remove this.