### PR TITLE
Make sure SQLAlchemy recycles connections

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -41,7 +41,7 @@ def main():
 
     killhandler = KillHandler()
 
-    engine = create_engine(config.db)
+    engine = create_engine(config.db, pool_recycle=60)
     sm = sessionmaker(bind=engine)
     
     reddit = praw.Reddit(client_id=config.client_id,

--- a/src/main.py
+++ b/src/main.py
@@ -234,7 +234,7 @@ def main():
     logging.info("Setting up database")
 
     killhandler = KillHandler()
-    engine = create_engine(config.db)
+    engine = create_engine(config.db, pool_recycle=60)
     sm = scoped_session(sessionmaker(bind=engine))
     worker = CommentWorker(sm)
 


### PR DESCRIPTION
This avoids having them age past the MariaDB wait_timeout of 600, after
which the db will forcibly close them, causing main.py or calculate.py
to fail a db operation.

Local testing indicates this fixes #141 but it's possible the real server behaves somewhat differently.