### PR TITLE
Sort leaderboard by net worth instead of balance

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -119,8 +119,8 @@
                                 <thead>
                                 <tr>
                                     <th>Name</th>
-                                    <th>balance</th>
-                                    <th>investments</th>
+                                    <th>Net worth</th>
+                                    <th>Completed investments</th>
                                 </tr>
                                 </thead>
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -209,7 +209,7 @@ let leaderboard = (function(){
              let badge = top[i].broke>0? '<span class="red bankrupt-badge white-text">'+top[i].broke+'</span>':"";
              // all in badge <span class="amber badge white-text">all in 3</span>
              html += "<tr><td>"+top[i].name + badge+"</td>"+
-                         "<td>"+formatToUnits(top[i].balance)+"</td>"+
+                         "<td>"+formatToUnits(top[i].networth)+"</td>"+
                          "<td>"+top[i].completed+"</td></tr>"
           }
       tb.innerHTML = html

--- a/src/message.py
+++ b/src/message.py
@@ -220,7 +220,7 @@ def modify_market(inves, cap, invs_cap):
 
 # Message used for !top command
 top_org = """
-Investors with the largest balances:
+Investors with the highest net worth (balance + active investments):
 
 %TOP_STRING%
 """
@@ -228,7 +228,7 @@ Investors with the largest balances:
 def modify_top(leaders):
     top_string = ""
     for l in leaders:
-        top_string = f"{top_string}\n\n{l.name}: {l.balance} MemeCoins"
+        top_string = f"{top_string}\n\n{l.name}: {int(l.networth)} MemeCoins"
 
     top_response = top_org
     top_response = top_response.replace("%TOP_STRING%", top_string)

--- a/src/models.py
+++ b/src/models.py
@@ -20,7 +20,7 @@ class Investment(Base):
     post = Column(String(11), nullable=False)
     upvotes = Column(Integer, default=0)
     comment = Column(String(11), nullable=False, unique=True)
-    name = Column(String(20), nullable=False)
+    name = Column(String(20), nullable=False, index=True)
     amount = Column(BigInteger, default=100)
     time = Column(Integer, server_default=unix_timestamp())
     done = Column(Boolean, default=False, nullable=False)


### PR DESCRIPTION
Currently, the leaderboard shows the users with the highest balances,
but this is probably not the best indicator of our top investors. The
top investors are the ones with the highest net worth, i.e. balance plus
value of active investments. Also updates the !top command to match.

Fixes #145 