### PR TITLE
Cache the expensive /investors/top API call

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 https://github.com/praw-dev/praw/archive/master.zip
 fastnumbers
 flask
+flask-caching
 flask-cors
 flask-sqlalchemy
 gunicorn

--- a/src/api.py
+++ b/src/api.py
@@ -1,6 +1,7 @@
 import json
 
 from flask import Flask, jsonify, request
+from flask_caching import Cache
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import desc, func, and_
@@ -12,6 +13,9 @@ from formula import calculate
 app = Flask(__name__)
 app.config["SQLALCHEMY_DATABASE_URI"] = config.db
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+# Create a simple cache to store the results of some of our API calls
+cache = Cache(app, config={'CACHE_TYPE': 'simple'})
 
 db = SQLAlchemy(app)
 CORS(app)
@@ -131,6 +135,7 @@ def investments_total():
 
 
 @app.route("/investors/top")
+@cache.cached(timeout=10, query_string=True)
 def investors_top():
     page, per_page = get_pagination()
 


### PR DESCRIPTION
Basically, the leaderboard will no longer be calculated by the web API more than once every 10 seconds. So if there are a large number of users viewing the website, constantly pinging the API, it will no longer put a huge load on the server by constantly recomputing the leaderboard.

Fixes #171 