### PR TITLE
Return empty list of investments instead of 404

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -204,7 +204,8 @@ def investor_investments(name):
               limit(per_page).offset(page*per_page).all()
 
     if not sql_res:
-        return not_found("No investments found")
+        noRes = []
+        return jsonify(noRes)
 
     res = [{
         "id": x.id,

--- a/src/api.py
+++ b/src/api.py
@@ -83,9 +83,6 @@ def investments():
     sql_res = sql.order_by(Investment.id.desc()).\
               limit(per_page).offset(page*per_page).all()
 
-    if not sql_res:
-        return not_found("No investments found")
-
     res = [{
         "id": x.id,
         "post": x.post,
@@ -203,10 +200,6 @@ def investor_investments(name):
     sql_res = sql.order_by(Investment.id.desc()).\
               limit(per_page).offset(page*per_page).all()
 
-    if not sql_res:
-        noRes = []
-        return jsonify(noRes)
-
     res = [{
         "id": x.id,
         "post": x.post,
@@ -240,9 +233,6 @@ def investor_active(name):
 
     sql_res = sql.order_by(Investment.id.desc()).\
               limit(per_page).offset(page*per_page).all()
-
-    if not sql_res:
-        return not_found("No investments found")
 
     res = [{
         "id": x.id,


### PR DESCRIPTION
Re: Issue #194

Returns ```[]``` instead of null when a user's investments are queried and they have none.

**I don't know if this breaks anything API related, and I currently have no way of testing. Please review before merging. Thanks :)**
