### PR TITLE
Automatically create account for new users

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -26,7 +26,11 @@ def req_user(fn):
             first()
 
         if not investor:
-            return self.no_such_user(comment)
+            self.create(sess, comment)
+            time.sleep(5) # avoid rapid back-to-back comments
+            investor = sess.query(Investor).\
+                filter(Investor.name == comment.author.name).\
+                first()
 
         return fn(self, sess, comment, investor, *args)
     return wrapper
@@ -238,10 +242,6 @@ class CommentWorker():
             all()
 
         comment.reply_wrap(message.modify_active(active_investments))
-
-    def no_such_user(self, comment):
-        comment.reply_wrap(message.no_account_org)
-
 
 def main():
     logging.info("Starting main")

--- a/src/message.py
+++ b/src/message.py
@@ -10,7 +10,7 @@ create_org = """
 
 Thank you %USERNAME% for creating a bank account in r/MemeEconomy!
 
-Your current balance is %BALANCE% MemeCoins.
+Your starting balance is %BALANCE% MemeCoins.
 """
 
 def modify_create(username, balance):
@@ -203,12 +203,6 @@ Here is a list of commands that summon me:
 For market stats and more information, visit [memes.market](https://memes.market).
 
 You can help improve me by contributing to my source code on [GitHub](https://github.com/MemeInvestor/memeinvestor_bot).
-"""
-
-no_account_org = """
-You do not have permission to perform this operation.
-
-Please create an account with the !create command.
 """
 
 balance_org = """


### PR DESCRIPTION
Upon seeing any command that requires a user account (!invest, !balance,
!broke, etc.) the bot will first create a new account for the user if
necessary, then execute the command. This means the bot makes two
replies to the user in this case.

Tested locally.

Fixes #149