### PR TITLE
Add /summary API and reject malformed requests

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,7 +1,7 @@
 {$CADDY_WEB_ADDRESS} {
 	root /static
-	proxy /api api:5000 {
-		without /api
+	proxy /api/ api:5000 {
+		without /api/
 		transparent
 	}
 

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -1,5 +1,5 @@
 import {connectionErrorToast} from './modules/uiElements.js';
-import * as jsonApi from './modules/jsonApi.js';
+import * as jsonApi from './modules/jsonApi.js?c=1';
 import {formatToUnits, iterateDays} from './modules/dataUtils.js';
 import {Scheduler} from './modules/scheduler.js';
 

--- a/docs/js/leaderboards.js
+++ b/docs/js/leaderboards.js
@@ -1,5 +1,5 @@
 import {connectionErrorToast} from './modules/uiElements.js';
-import * as jsonApi from './modules/jsonApi.js';
+import * as jsonApi from './modules/jsonApi.js?c=1';
 import {formatToUnits, getSuffix} from './modules/dataUtils.js';
 
 let leaderboard = (function(){

--- a/docs/js/modules/jsonApi.js
+++ b/docs/js/modules/jsonApi.js
@@ -31,7 +31,7 @@ function makeRequest (param, options) {
 }
 
 export function getAll(){
-   return makeRequest("?per_page=5", options);
+   return makeRequest("/summary?per_page=5", options);
 }
 
 export function get(param){

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -1,5 +1,5 @@
 import {connectionErrorToast} from './modules/uiElements.js';
-import * as jsonApi from './modules/jsonApi.js';
+import * as jsonApi from './modules/jsonApi.js?c=1';
 import {Scheduler} from './modules/scheduler.js';
 import {formatToUnits} from './modules/dataUtils.js';
 import {getFileName, getDescription} from './modules/badges.js';

--- a/src/api.py
+++ b/src/api.py
@@ -289,7 +289,7 @@ def investor_active(name):
     return jsonify(res)
 
 
-@app.route("/")
+@app.route("/summary")
 def index():
     data = {
         "coins": {


### PR DESCRIPTION
Instead of proxying the /api prefix to our API server, we are
now proxying the /api/ prefix. This prevents requests like
/apicoins from working. Also replaced the / endpoint with the more
explanatory /summary

Tested locally.

Fixes #185