### PR TITLE
Add !grant command to give out specific badges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ BOT_PREVENT_INSIDERS=0
 BOT_INVESTMENT_DURATION=14400
 
 ###############################################################################
+# Configure Reddit accounts to treat as "admins." These accounts can use the
+# !grant command to give investors badges. Comma-separated list.
+###############################################################################
+
+BOT_ADMIN_REDDIT_ACCOUNTS=
+
+###############################################################################
 # Configure Reddit access. See the guide on
 # praw.readthedocs.io/en/latest/getting_started/quick_start.html
 # for details on generating your own bot credentials.

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,7 @@ post_to_reddit      = int(os.environ['BOT_POST_TO_REDDIT'])
 is_moderator        = int(os.environ['BOT_IS_MODERATOR'])
 prevent_insiders    = int(os.environ['BOT_PREVENT_INSIDERS'])
 investment_duration = int(os.environ['BOT_INVESTMENT_DURATION'])
-admin_accounts      = os.environ['BOT_INVESTMENT_DURATION'].split(',')
+admin_accounts      = os.environ['BOT_ADMIN_REDDIT_ACCOUNTS'].split(',')
 
 client_id     = os.environ['BOT_CLIENT_ID']
 client_secret = os.environ['BOT_CLIENT_SECRET']

--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,7 @@ post_to_reddit      = int(os.environ['BOT_POST_TO_REDDIT'])
 is_moderator        = int(os.environ['BOT_IS_MODERATOR'])
 prevent_insiders    = int(os.environ['BOT_PREVENT_INSIDERS'])
 investment_duration = int(os.environ['BOT_INVESTMENT_DURATION'])
+admin_accounts      = os.environ['BOT_INVESTMENT_DURATION'].split(',')
 
 client_id     = os.environ['BOT_CLIENT_ID']
 client_secret = os.environ['BOT_CLIENT_SECRET']

--- a/src/main.py
+++ b/src/main.py
@@ -65,6 +65,7 @@ class CommentWorker():
         r"!invest ([\d,]+)",
         r"!market",
         r"!top",
+        r"!grant",
     ]
 
     def __init__(self, sm):
@@ -242,6 +243,15 @@ class CommentWorker():
             all()
 
         comment.reply_wrap(message.modify_active(active_investments))
+
+    def grant(self, sess, comment, grantee, badge):
+        author = comment.author.name
+
+        if author in config.admin_accounts:
+            comment.reply_wrap(message.modify_grant())
+            return
+
+        # if sess.query(Investor).filter(Investor.name == author).exists().scalar()
 
 def main():
     logging.info("Starting main")

--- a/src/main.py
+++ b/src/main.py
@@ -65,7 +65,7 @@ class CommentWorker():
         r"!invest ([\d,]+)",
         r"!market",
         r"!top",
-        r"!grant",
+        r"!grant (\S+) (\S+)",
     ]
 
     def __init__(self, sm):
@@ -246,6 +246,10 @@ class CommentWorker():
 
     def grant(self, sess, comment, grantee, badge):
         author = comment.author.name
+
+        logging.info(f"Received args: {grantee}, {badge}")
+        logging.info(f"Author: {author}")
+        logging.info(f"Admins: {config.admin_accounts}")
 
         if author in config.admin_accounts:
             comment.reply_wrap(message.modify_grant())

--- a/src/message.py
+++ b/src/message.py
@@ -284,3 +284,6 @@ To prevent thread spam and other natural disasters, I only respond to direct rep
 inside_trading_org = """
 You can't invest in your own memes, insider trading is not allowed!
 """
+
+def modify_grant():
+    return "Granted!"

--- a/src/message.py
+++ b/src/message.py
@@ -285,5 +285,8 @@ inside_trading_org = """
 You can't invest in your own memes, insider trading is not allowed!
 """
 
-def modify_grant():
-    return "Granted!"
+def modify_grant_success(grantee, badge):
+    return f"Successfully granted badge `{badge}` to {grantee}!"
+
+def modify_grant_failure(failure_message):
+    return f"Oops, I couldn't grant that badge ({failure_message})"


### PR DESCRIPTION
Until we have automatic badge assignment, we can use this command to give out individual badges. The syntax is:

```
!grant <username> <badge-name>
```

Only one user at a time, only one badge at a time. Does not check if `<badge-name>` is a valid badge.

The person issuing the command must be in the list of bot admins defined in `.env`.