### PR TITLE
Made the time formatting more agile.

### DIFF
--- a/src/message.py
+++ b/src/message.py
@@ -33,7 +33,7 @@ I love the enthusiasm, but you've already got an account!
 invest_org = """
 *%AMOUNT% MemeCoins invested @ %INITIAL_UPVOTES% upvotes*
 
-Your investment is active. I'll evaluate your return in %TIME% and update this comment. Stay tuned!
+Your investment is active. I'll evaluate your return in %TIME%and update this comment. Stay tuned!
 
 Your current balance is %BALANCE% MemeCoins.
 """.replace("%TIME%", investment_duration_var)

--- a/src/message.py
+++ b/src/message.py
@@ -3,6 +3,33 @@ import time
 
 import config
 
+def investment_duration_string(duration):
+    hours = duration // 3600
+    duration %= 3600
+    minutes = duration // 60
+    duration %= 60
+
+    inv_string = ""
+    if (hours):
+        inv_string += f"{hours} hour"
+        if (hours > 1):
+            inv_string += "s "
+        inv_string += " "
+    if (minutes):
+        inv_string += f"{minutes} minute"
+        if (minutes > 1):
+            inv_string += "s "
+        inv_string += " "
+    if (duration):
+        inv_string += f"{duration} second"
+        if (duration > 1):
+            inv_string += "s "
+        inv_string += " "
+
+    return inv_string
+
+investment_duration_var = investment_duration_string(config.investment_duration)
+
 # This message will be sent if an account has been
 # successfully created
 create_org = """
@@ -30,10 +57,10 @@ I love the enthusiasm, but you've already got an account!
 invest_org = """
 *%AMOUNT% MemeCoins invested @ %INITIAL_UPVOTES% upvotes*
 
-Your investment is active. I'll evaluate your return in 4 hours and update this comment. Stay tuned!
+Your investment is active. I'll evaluate your return in %TIME% and update this comment. Stay tuned!
 
 Your current balance is %BALANCE% MemeCoins.
-"""
+""".replace("%TIME%", investment_duration_var)
 
 def modify_invest(amount, initial_upvotes, new_balance):
     return invest_org.\

--- a/src/message.py
+++ b/src/message.py
@@ -2,33 +2,9 @@ import datetime
 import time
 
 import config
+import utils
 
-def investment_duration_string(duration):
-    hours = duration // 3600
-    duration %= 3600
-    minutes = duration // 60
-    duration %= 60
-
-    inv_string = ""
-    if (hours):
-        inv_string += f"{hours} hour"
-        if (hours > 1):
-            inv_string += "s "
-        inv_string += " "
-    if (minutes):
-        inv_string += f"{minutes} minute"
-        if (minutes > 1):
-            inv_string += "s "
-        inv_string += " "
-    if (duration):
-        inv_string += f"{duration} second"
-        if (duration > 1):
-            inv_string += "s "
-        inv_string += " "
-
-    return inv_string
-
-investment_duration_var = investment_duration_string(config.investment_duration)
+investment_duration_var = utils.investment_duration_string(config.investment_duration)
 
 # This message will be sent if an account has been
 # successfully created

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,24 @@
+def investment_duration_string(duration):
+    hours = duration // 3600
+    duration %= 3600
+    minutes = duration // 60
+    duration %= 60
+
+    inv_string = ""
+    if (hours):
+        inv_string += f"{hours} hour"
+        if (hours > 1):
+            inv_string += "s "
+        inv_string += " "
+    if (minutes):
+        inv_string += f"{minutes} minute"
+        if (minutes > 1):
+            inv_string += "s "
+        inv_string += " "
+    if (duration):
+        inv_string += f"{duration} second"
+        if (duration > 1):
+            inv_string += "s "
+        inv_string += " "
+
+    return inv_string


### PR DESCRIPTION
While testing other features, we needed to decrease the `investment_duration` value in our `.env` file. So I thought if the future we will increase or decrease investments' durations, the message should handle it automatically and format it as needed. For example, if I set the value to `13999`, it will tell me `I'll evaluate your return in 3 hours 59 minutes 59 seconds and update this comment.` Grammar is agile too. With the value of `3661`, it will reply accordingly - `I'll evaluate your return in 1 hour 1 minute 1 second and update this comment.`.

[Testing](https://www.reddit.com/r/memeinvestor_test/comments/93dg39/testing_time/)

The code is purely pythonic. By that, I mean that I don't use any fast hacks or ambiguous code. Just, plain simple programming, whose intentions can be immediately understood.