### PR TITLE
user: Render time of investment using locale date format

### DIFF
--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -390,7 +390,7 @@ let investments = (function(){
       `
       for(let inv of data){
          let invTime = new Date(inv.time*1000)
-         let time = invTime.toLocaleString()
+         let time = invTime.toLocaleTimeString([], {hour: '2-digit', minute:'2-digit', hour12: false})
          let date = invTime.getDate()+'/'+monthNames[invTime.getMonth()]
          html += `
          <tr>

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -390,7 +390,7 @@ let investments = (function(){
       `
       for(let inv of data){
          let invTime = new Date(inv.time*1000)
-         let time = invTime.getHours()+':'+invTime.getMinutes()
+         let time = invTime.toLocaleString()
          let date = invTime.getDate()+'/'+monthNames[invTime.getMonth()]
          html += `
          <tr>


### PR DESCRIPTION
The primary impetus here is that invTime.getMinutes() does not return a zero-prefixed two digit number for investments in the first 10 minutes of the hour. Seeing as most browsers know how to render based on locale, this seems like a very logical change to me, as it means that this function no longer needs to deal with its own time style.

(In lieu of another library e.g. moment, this is probably the easiest solution.)

Another option I could see would be to take the output from this function and `replace` to trim off any unwanted bits. I don't know if there's a tight attachment to this coding style, though.