### PR TITLE
Add ticker for most profitable users over last 24 hours.

### DIFF
--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -1,6 +1,77 @@
 
 @import 'dark-base.css';
 
+/* --[last 24 ticker]-- */
+.ticker-wrap{
+  width: 100%;
+  overflow: hidden;
+  height: 4rem;
+}
+
+.ticker{
+  display: inline-block;
+  width: 100%;
+  box-sizing: content-box;
+  
+  height: 4rem;
+  line-height: 4rem;
+  white-space: nowrap;
+
+  -webkit-animation-iteration-count: infinite; 
+          animation-iteration-count: infinite;
+  -webkit-animation-timing-function: linear;
+          animation-timing-function: linear;
+ -webkit-animation-name: ticker;
+         animation-name: ticker;
+  -webkit-animation-duration: 30s;
+          animation-duration: 30s;
+
+}
+
+.ticker-item{
+  display: inline-block;
+  padding: 0 2rem;
+  font-size: 1.5rem;
+  color: white;
+}
+
+.last24-header{
+  font-weight: bold;
+}
+
+.last24-position-1{
+  color: #FFD700;
+}
+.last24-profit{
+  font-style: italic;
+}
+
+@-webkit-keyframes ticker{
+  0%{
+    -webkit-transform: translate3d(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);
+    visibility: visible;
+  }
+
+  100%{
+    -webkit-transform: translate3d(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0);
+  }
+}
+
+@keyframes ticker{
+  0%{
+    -webkit-transform: translate3d(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);
+    visibility: visible;
+  }
+
+  100%{
+    -webkit-transform: translate3d(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0);
+  }
+}
+
 /* --[graph row]-- */
 .chart-wrap{
   height:300px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,6 +121,17 @@
                 </div>
             </div>
             <div class="divider"></div>
+            <div class="ticker-wrap">
+                <div class="ticker last24-ticker">
+                  <div class="ticker-item last24-header">Profit Today:</div>
+                  <div class="ticker-item last24-item">--- ---</div>
+                  <div class="ticker-item last24-item">--- ---</div>
+                  <div class="ticker-item last24-item">--- ---</div>
+                  <div class="ticker-item last24-item">--- ---</div>
+                  <div class="ticker-item last24-item">--- ---</div>
+                </div>
+            </div>
+            <div class="divider"></div>
             <div class="section">
                 <div class="row">
                     <div class="col s12 m8 l8">

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -3,6 +3,27 @@ import * as jsonApi from './modules/jsonApi.js?c=2';
 import {formatToUnits, iterateDays} from './modules/dataUtils.js?c=1';
 import {Scheduler} from './modules/scheduler.js';
 
+let ticker = (function(){
+   function init() {
+      jsonApi.get('/investors/last24').then(function (top5) {
+         var tickerElements = document.getElementsByClassName("last24-item");
+         for (var i = tickerElements.length - 1; i >= 0; i--) {
+             tickerElements[i].innerHTML = `
+               <span class="last24-name">${top5[i].name}:</span>
+               <span class="last24-profit">${top5[i].profit}</span>
+             `
+             tickerElements[i].className += " last24-position-" + (i+1)
+          } 
+      });
+   }
+
+   return {
+      init: init,
+      update: function() {} // there isn't any real reason to update this, it's cached by the hour.
+      // update: init
+   }
+})();
+
 let overview = (function(){
    let counters = {
       coinsInvested: undefined,
@@ -266,6 +287,7 @@ let investmentsCalculator = (function() {
       overview.init()
       overviewChart.init()
       investmentsCalculator.init()
+      ticker.init()
       //init short polling update schedulers
       let dataUpdater = new Scheduler(
          function(){


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4183876/46816939-ed3f0c80-cd75-11e8-8809-7eadb7f31456.png)

Scrolls on a 30 second loop. Takes users with most profitable completed investments made in the past 24 hours. API endpoint is `investors/last24` & is cached per hour, returning only top 5 w/ name and profit.

Fixes #177 
