### PR TITLE
Number literals/suffixes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -190,7 +190,7 @@ class CommentWorker():
 
         try:
             amount = float(amount.replace(',',''))
-            amount = int(amount * CommentWorker.multiplier[suffix])
+            amount = int(amount * CommentWorker.multipliers[suffix])
         except ValueError:
             return
 

--- a/src/main.py
+++ b/src/main.py
@@ -61,9 +61,10 @@ class CommentWorker():
         'k': 1e3,
         'm': 1e6,
         'b': 1e9,
-        'quad': 1e12,
-        'quin': 1e15,  # Has to be above q, or regex will stop at q instead of searching for quin/quad
-        'q': 1e12
+        't': 1e12,
+        'quad': 1e15,
+        'quin': 1e18,  # Has to be above q, or regex will stop at q instead of searching for quin/quad
+        'q': 1e15
     }
 
     commands = [

--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ class CommentWorker():
         r"!create",
         r"!help",
         r"!ignore",
-        r"!invest\s+([\d,.]+)\s+(%s)" % "|".join(multipliers),
+        r"!invest\s+([\d,.]+)\s?(%s)" % "|".join(multipliers),
         r"!market",
         r"!top",
         r"!grant\s+(\S+)\s+(\S+)",

--- a/src/main.py
+++ b/src/main.py
@@ -74,7 +74,7 @@ class CommentWorker():
         r"!create",
         r"!help",
         r"!ignore",
-        r"!invest\s+([\d,.]+)\s?(%s)" % "|".join(multipliers),
+        r"!invest\s+([\d,.]+)\s*(%s)?" % "|".join(multipliers),
         r"!market",
         r"!top",
         r"!grant\s+(\S+)\s+(\S+)",

--- a/src/main.py
+++ b/src/main.py
@@ -190,7 +190,7 @@ class CommentWorker():
 
         try:
             amount = float(amount.replace(',',''))
-            amount = int(amount * multiplier[suffix])
+            amount = int(amount * CommentWorker.multiplier[suffix])
         except ValueError:
             return
 

--- a/src/main.py
+++ b/src/main.py
@@ -57,6 +57,15 @@ praw.models.Comment.reply_wrap = reply_wrap
 
 
 class CommentWorker():
+    multipliers = {
+        'k': 1e3,
+        'm': 1e6,
+        'b': 1e9,
+        'quad': 1e12,
+        'quin': 1e15,  # Has to be above q, or regex will stop at q instead of searching for quin/quad
+        'q': 1e12
+    }
+
     commands = [
         r"!active",
         r"!balance",
@@ -64,7 +73,7 @@ class CommentWorker():
         r"!create",
         r"!help",
         r"!ignore",
-        r"!invest\s+([\d,]+)",
+        r"!invest\s+([\d,.]+)\s+(%s)" % "|".join(multipliers),
         r"!market",
         r"!top",
         r"!grant\s+(\S+)\s+(\S+)",
@@ -169,7 +178,7 @@ class CommentWorker():
         comment.reply_wrap(message.modify_create(comment.author, 1000))
 
     @req_user
-    def invest(self, sess, comment, investor, amount):
+    def invest(self, sess, comment, investor, amount, suffix):
         if not isinstance(comment, praw.models.Comment):
             return
 
@@ -179,7 +188,8 @@ class CommentWorker():
                 return
 
         try:
-            amount = int(amount.replace(',',''))
+            amount = float(amount.replace(',',''))
+            amount = int(amount * multiplier[suffix])
         except ValueError:
             return
 


### PR DESCRIPTION
I added a feature where you can add suffixes to the end of the numbers to specify a multiplier/unit
These are all valid:
```
1k    // Evaluates to 1000
1K    // ^
1 k   // ^
1 K   // ^
1.2k  // Evaluates to 1200
2m    // Evaluates to 2000000
2.1 M // Evaluates to 2100000
```
Etc, for all the multipliers found in `main.py`

I tested the change in r/MemeInvestor_test, but as I was getting rate limited, I had it print everything to console, here are the logs for one of the tests:
```
bot_1         | INFO:root:New comment e8g0w2i:
bot_1         | INFO:root: -- retrieved in 17.28s
bot_1         | INFO:root: -- rust4yy: !invest 1k
bot_1         | INFO:root: -- replying
bot_1         | INFO:root:
bot_1         | *1,000 MemeCoins invested @ 0 upd00ts*
bot_1         | 
bot_1         | Your investment is active. I'll evaluate your return in 1 second and update this comment. Stay tuned!
bot_1         | 
bot_1         | Your current balance is **0 MemeCoins**.
bot_1         | 
bot_1         | INFO:root: -- processed in  2.33s
bot_1         | INFO:root: -- API calls remaining: 563, resetting in 184s
calculator_1  | INFO:root:New mature investment: e8g0w2i
calculator_1  | INFO:root: -- by rust4yy
calculator_1  | INFO:root: -- lost -631
calculator_1  | INFO:root: -- editing fake response
calculator_1  | INFO:root:
calculator_1  | *1,000 MemeCoins invested @ 0 upd00ts*
calculator_1  | 
calculator_1  | UPDATE: Your investment has matured. It was unsuccessful! You lost 631 MemeCoins (-63%).
calculator_1  | 
calculator_1  | *369 MemeCoins returned @ 0 upd00ts*
calculator_1  | 
calculator_1  | Your new balance is **369 MemeCoins**.
calculator_1  | 
calculator_1  | ^(formula v3)
calculator_1  | 
calculator_1  | INFO:root: -- processed in  1.15s
calculator_1  | INFO:root: -- API calls remaining: 561, resetting in 182s
```

Thanks!

edit: formatting. Was done on mobile. If it’s still messed up will update tomorrow on pc
