### PR TITLE
Mixed number handling for !invest messages

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -183,6 +183,14 @@ class CommentWorker():
         except ValueError:
             return
 
+        multipliers = {'K': 1e3,'M': 1e6,'B': 1e9,'T': 1e12,'q': 1e15,'Q': 1e18}
+        pattern = r'([0-9.]+)([KMBTqQ])'
+        temp_amount = 0
+        for number, suffix in re.findall(pattern, amount):
+            number = float(number)
+            temp_amount += (number * multipliers[suffix])
+        amount = temp_amount 
+
         if amount < 100:
             comment.reply_wrap(message.min_invest_org)
             return


### PR DESCRIPTION
I'm submitting my version of a word-to-text converter for !invest messages.
It converts messages that look like "!invest 1.32Q" or "!invest 46q 4M 1591K" into 13200000000000000 and 46000000041591000 (for example).

The advantage to my version is that it is relatively short and efficient, while being able to accept as many 'mixed numbers' as the user chooses. I.e. "!invest 3Q 4K" will work, because it adds all of the mixed numbers together.

It can be seen to work in this thread: https://www.reddit.com/r/memeinvestor_test/comments/9rdl32/please_lord/

Thanks!
Aculisme