### PR TITLE
Client-side Investment Calculation

### DIFF
--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -290,25 +290,12 @@ let investmentsCalculator = (function() {
             </div>
           </div>
          </div>`
-         console.log('this is a test');
          let factor = C(start, end);
          let output = (amount * factor).toFixed();
          output = isNaN(output)?"invalid data":output;
          output = (output+[]).length>20?formatToUnits(output):output;
          //replaces the spinning loader with the calculated result
          document.getElementById('investment-result').innerText = output;
-         /**jsonApi.get('http://memes.market/calculate?old='+start+'&new='+end).then(function(data) {
-            let factor = data.factor.valueOf()
-            let output = (amount * factor).toFixed();
-            output = isNaN(output)?"invalid data":output;
-            output = (output+[]).length>20?formatToUnits(output):output;
-            //replaces the spinning loader with the calculated result
-            document.getElementById('investment-result').innerText = output;
-         }).catch(function(er){
-            connectionErrorToast(er,'connection error');
-            //removes the spinnign loader
-            document.getElementById('investment-result').innerText = '000';
-         });**/
       }else{
          document.getElementById('investment-result').innerText = 'invalid data';
          let toastHTML = 'you have to fill all the fields with a valid number'


### PR DESCRIPTION
Based on [u/ChefOfRamen's suggestion from the subreddit](https://www.reddit.com/r/MemeInvestor_bot/comments/9ufdq2/faster_investment_calculator/), this moves investment calculation on [memes.market](http://memes.market/) client-side rather than server-side. In other words, instead of the homepage making an API call to the Python that calculates investment returns, it does these calculations in the JavaScript. The benefit of this change is that it frees up resources on the server and greatly improves the calculation speed for users.
The improvement makes no changes to the bot or algorithm itself and the code for calculating the investment returns is taken directly from `calculator.py`, just rewritten in JavaScript.
[Here](https://imgur.com/a/VE4ZdWt) are screenshots of side-by-side tests of the new, client-side code and the server-side code already in use.