### PR TITLE
Fixed gunicorn WYSG variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,11 @@ services:
         depends_on:
           - mysql
 
-
     api:
         build: .
         env_file: .env
         restart: unless-stopped
-        command: [".local/bin/gunicorn", "--bind", "0.0.0.0:5000", "--access-logfile", "-", "--error-logfile", "-", "api:app"]
+        command: [".local/bin/gunicorn", "--bind", "0.0.0.0:5000", "--access-logfile", "-", "--error-logfile", "-", "api:APP"]
         depends_on:
           - mysql
 


### PR DESCRIPTION
I was getting the following error

```
api_1         | [2018-12-24 17:27:33 +0000] [1] [INFO] Starting gunicorn 19.9.0
api_1         | [2018-12-24 17:27:33 +0000] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
api_1         | [2018-12-24 17:27:33 +0000] [1] [INFO] Using worker: sync
api_1         | [2018-12-24 17:27:33 +0000] [8] [INFO] Booting worker with pid: 8
api_1         | Failed to find application object 'app' in 'api'
api_1         | [2018-12-24 17:27:34 +0000] [8] [INFO] Worker exiting (pid: 8)
api_1         | [2018-12-24 17:27:34 +0000] [1] [INFO] Shutting down: Master
api_1         | [2018-12-24 17:27:34 +0000] [1] [INFO] Reason: App failed to load.
```

It happened because I made the `app` variable all uppercase `APP` because it is a global variable and by the PEP8 coding style, it should be all UPPERCASE. My bad, I forgot the binding in the `docker-compose` config file. It is finally fixed now and api can get working again. Thank you.
