### PR TITLE
Added !template command

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -375,8 +375,8 @@ class CommentWorker():
 
         # If OP posted a template, replace the hint
         edited_response = comment.parent().body.replace(message.TEMPLATE_HINT_ORG.
-                                                        replace("%NAME%", f'u/{comment.author.name}'), '')
-        edited_response += message.modify_template_op(link, 'u/' + comment.author.name)
+                                                        replace("%NAME%", f"u/{comment.author.name}"), '')
+        edited_response += message.modify_template_op(link, f"u/{comment.author.name}")
 
         return comment.parent().edit_wrap(edited_response)
 

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -374,8 +374,9 @@ class CommentWorker():
             return
 
         # If OP posted a template, replace the hint
-        edited_response = comment.parent().body.replace(message.TEMPLATE_HINT_ORG, '')
-        edited_response += message.modify_template_op(link)
+        edited_response = comment.parent().body.replace(message.TEMPLATE_HINT_ORG.
+                                                        replace("%NAME%", f'u/{comment.author.name}'), '')
+        edited_response += message.modify_template_op(link, 'u/' + comment.author.name)
 
         return comment.parent().edit_wrap(edited_response)
 

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -353,25 +353,22 @@ class CommentWorker():
         """
         OP can submit the template link to the bot's sticky
         """
+        
         # Type of comment is praw.models.reddit.comment.Comment, which
         # does not have a lot of documentation in the docs, for more
         # informationg go to
         # github.com/praw-dev/praw/blob/master/praw/models/reddit/comment.py
-
-        # Checking if the comment's author is
-        # the submission's author
-        # For some reason, `comment.is_submitter` doesn't work
         comment.refresh()
         if not comment.is_submitter:
             return comment.reply_wrap(message.TEMPLATE_NOT_OP)
 
         # Checking if the upper comment is the bot's sticky
         if not comment.parent().stickied:
-            return
+            return comment.reply_wrap(message.TEMPLATE_NOT_STICKY)
 
         # What if user spams !template commands?
         if comment.parent().edited:
-            return
+            return comment.reply_wrap(message.TEMPLATE_ALREADY_DONE)
 
         # If OP posted a template, replace the hint
         edited_response = comment.parent().body.replace(message.TEMPLATE_HINT_ORG.

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -108,7 +108,7 @@ class CommentWorker():
         r"!market",
         r"!top",
         r"!grant\s+(\S+)\s+(\S+)",
-        r"!template\s+https?://(.+)",
+        r"!template\s+(https://imgur.com/.+)",
         r"!firm",
         r"!createfirm\s+(.+)",
         r"!joinfirm\s+(.+)",
@@ -353,7 +353,7 @@ class CommentWorker():
         """
         OP can submit the template link to the bot's sticky
         """
-        
+
         # Type of comment is praw.models.reddit.comment.Comment, which
         # does not have a lot of documentation in the docs, for more
         # informationg go to

--- a/src/main.py
+++ b/src/main.py
@@ -88,7 +88,7 @@ def main():
         for comment in praw.models.util.stream_generator(reply_function):
             # Measure how long since we finished the last loop iteration
             duration = stopwatch.measure()
-            logging.info("New comment %s:", comment)
+            logging.info("New comment %s (%s):", comment, type(comment))
             logging.info(" -- retrieved in %.2fs", duration)
 
             if comment.new:

--- a/src/message.py
+++ b/src/message.py
@@ -517,7 +517,7 @@ Action failed.
 TEMPLATE_OP = """
 ---
 
-%NAME% has posted the [link to the template](https://%LINK%), Hurray!
+OP %NAME% has posted *[THE LINK TO THE TEMPLATE](https://%LINK%)*, Hurray!
 """
 
 def modify_template_op(link, name):

--- a/src/message.py
+++ b/src/message.py
@@ -283,6 +283,12 @@ Where did he go?
 Whatever, investment is lost.
 """
 
+TEMPLATE_HINT_ORG = """
+---
+
+Psst, OP, you can invoke `!template https://example.org` command to publicly post your template!
+"""
+
 INVEST_PLACE_HERE_NO_FEE = """
 **INVESTMENTS GO HERE - ONLY DIRECT REPLIES TO ME WILL BE PROCESSED**
 
@@ -295,7 +301,7 @@ To prevent thread spam and other natural disasters, I only respond to direct rep
 - Visit /r/MemeInvestor_bot for questions or suggestions about me.
 
 - Support the project via our [patreon](https://www.patreon.com/memeinvestor_bot)
-"""
+""" + TEMPLATE_HINT_ORG
 
 INVEST_PLACE_HERE = """
 **INVESTMENTS GO HERE - ONLY DIRECT REPLIES TO ME WILL BE PROCESSED**
@@ -309,7 +315,7 @@ The author of this post paid **%MEMECOIN% MemeCoins** to post this.
 - Visit [memes.market](https://memes.market) for help, market statistics, and investor profiles.
 
 - Visit /r/MemeInvestor_bot for questions or suggestions about me.
-"""
+""" + TEMPLATE_HINT_ORG
 
 def modify_invest_place_here(amount):
     return INVEST_PLACE_HERE.\
@@ -496,3 +502,19 @@ def modify_firm_tax(tax_amount, firm_name):
     return FIRM_TAX_ORG.\
         replace("%AMOUNT%", tax_amount).\
         replace("%NAME%", firm_name)
+
+TEMPLATE_NOT_OP = """
+Sorry, but you are not the submission's Original Poster.
+
+Action failed.
+"""
+
+TEMPLATE_OP = """
+---
+
+OP has posted the [link to the template](https://%LINK%), Hurray!
+"""
+
+def modify_template_op(link):
+    return TEMPLATE_OP.\
+        replace("%LINK%", link)

--- a/src/message.py
+++ b/src/message.py
@@ -510,8 +510,14 @@ def modify_firm_tax(tax_amount, firm_name):
 
 TEMPLATE_NOT_OP = """
 Sorry, but you are not the submission's Original Poster.
+"""
 
-Action failed.
+TEMPLATE_ALREADY_DONE = """
+Sorry, but you already submitted the template link.
+"""
+
+TEMPLATE_NOT_STICKY = """
+Sorry, you have to *directly* reply to the bot's sticky.
 """
 
 TEMPLATE_OP = """

--- a/src/message.py
+++ b/src/message.py
@@ -286,7 +286,7 @@ Whatever, investment is lost.
 TEMPLATE_HINT_ORG = """
 ---
 
-Psst, %NAME%, you can invoke `!template https://example.org` command to publicly post your template!
+Psst, %NAME%, you can invoke `!template https://imgur.com/...` command to publicly post your template!
 """
 
 INVEST_PLACE_HERE_NO_FEE = """
@@ -523,7 +523,7 @@ Sorry, you have to *directly* reply to the bot's sticky.
 TEMPLATE_OP = """
 ---
 
-OP %NAME% has posted *[THE LINK TO THE TEMPLATE](https://%LINK%)*, Hurray!
+OP %NAME% has posted *[THE LINK TO THE TEMPLATE](%LINK%)*, Hurray!
 """
 
 def modify_template_op(link, name):

--- a/src/message.py
+++ b/src/message.py
@@ -286,7 +286,7 @@ Whatever, investment is lost.
 TEMPLATE_HINT_ORG = """
 ---
 
-Psst, OP, you can invoke `!template https://example.org` command to publicly post your template!
+Psst, %NAME%, you can invoke `!template https://example.org` command to publicly post your template!
 """
 
 INVEST_PLACE_HERE_NO_FEE = """
@@ -301,7 +301,11 @@ To prevent thread spam and other natural disasters, I only respond to direct rep
 - Visit /r/MemeInvestor_bot for questions or suggestions about me.
 
 - Support the project via our [patreon](https://www.patreon.com/memeinvestor_bot)
-""" + TEMPLATE_HINT_ORG
+"""
+
+def invest_no_fee(name):
+    return INVEST_PLACE_HERE_NO_FEE + TEMPLATE_HINT_ORG.\
+        replace("%NAME%", name)
 
 INVEST_PLACE_HERE = """
 **INVESTMENTS GO HERE - ONLY DIRECT REPLIES TO ME WILL BE PROCESSED**
@@ -317,9 +321,10 @@ The author of this post paid **%MEMECOIN% MemeCoins** to post this.
 - Visit /r/MemeInvestor_bot for questions or suggestions about me.
 """ + TEMPLATE_HINT_ORG
 
-def modify_invest_place_here(amount):
+def modify_invest_place_here(amount, name):
     return INVEST_PLACE_HERE.\
-        replace("%MEMECOIN%", format(int(amount), ",d"))
+        replace("%MEMECOIN%", format(int(amount), ",d")) + TEMPLATE_HINT_ORG.\
+        replace("%NAME%", name)
 
 INSIDE_TRADING_ORG = """
 You can't invest in your own memes, insider trading is not allowed!
@@ -512,9 +517,10 @@ Action failed.
 TEMPLATE_OP = """
 ---
 
-OP has posted the [link to the template](https://%LINK%), Hurray!
+%NAME% has posted the [link to the template](https://%LINK%), Hurray!
 """
 
-def modify_template_op(link):
+def modify_template_op(link, name):
     return TEMPLATE_OP.\
-        replace("%LINK%", link)
+        replace("%LINK%", link).\
+        replace("%NAME%", name)

--- a/src/submitter.py
+++ b/src/submitter.py
@@ -96,7 +96,7 @@ def main():
         # agile to switch between different modes
         if not config.SUBMISSION_FEE:
             # Post a comment to let people know where to invest
-            bot_reply = submission.reply_wrap(message.INVEST_PLACE_HERE_NO_FEE)
+            bot_reply = submission.reply_wrap(message.invest_no_fee(f"u/{submission.author.name}"))
         else:
             # If a poster doesn't have an account, delete the post
             # if he has, take 1000 MemeCoins and invest them
@@ -120,7 +120,7 @@ def main():
                 new_balance = investor.balance - required_fee
                 investor.balance = new_balance
                 bot_reply = submission.\
-                    reply_wrap(message.modify_invest_place_here(required_fee))
+                    reply_wrap(message.modify_invest_place_here(required_fee, f"u/{submission.author.name}"))
                 sess.commit()
 
         # Sticky the comment


### PR DESCRIPTION
Added `!template` command. 

OP can respond to the sticky comment and update it by publishing OP's template. Follow the examples below:

When just posted:
![deepinscreenshot_select-area_20190110130819](https://user-images.githubusercontent.com/16922860/50991026-4e8f8c80-14d9-11e9-91af-d78279378525.png)

After submitting a link:
![deepinscreenshot_select-area_20190110130834](https://user-images.githubusercontent.com/16922860/50991041-5a7b4e80-14d9-11e9-9071-c5d6a30548a9.png)

*NOTE* Please note that the bot will only accept comments that start with `http://` or `https://`

Closes #295