### PR TITLE
Added a dummy service and script for accessing the network.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,14 @@ services:
         depends_on:
           - mysql
 
+    tester:
+        build: .
+        env_file: .env
+        restart: on-failure
+        command: ["python", "tester.py"]
+        depends_on:
+          - mysql
+
     api:
         build: .
         env_file: .env

--- a/src/create_database.py
+++ b/src/create_database.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.schema import CreateTable
+
+import models
+import config
+
+def main():
+    print("Creating the engine...")
+    engine = create_engine(config.DB)
+    models.Base.metadata.create_all(engine)
+
+if __name__ == '__main__':
+    main()

--- a/src/tester.py
+++ b/src/tester.py
@@ -1,0 +1,8 @@
+import time
+
+def main():
+    while True:
+        time.sleep(10)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Sometimes we need to execute manual scripts. To do that we always used one of the python-based containers. If none of the services are running, it is becoming inconvenient at executing the scripts in python. This update add a dummy containers that will be in a network with the database and will be running `tester.py` script to stay alive.

`create-database.py` will initialize a database without explicitly deploying bot's containers.