### PR TITLE
As the website migrated. There are some adjustments I have to make.

### DIFF
--- a/docs/js/modules/jsonApi.js
+++ b/docs/js/modules/jsonApi.js
@@ -2,7 +2,7 @@
 let options = {
    method: "GET",
    //url: "/api",
-   url: "https://memes.market/api",
+   url: "https://meme.market/api",
    //url: "http://localhost/memeinvestor_bot/docs/testApiData.json",
 }
 function makeRequest (param = '', options) {

--- a/src/message.py
+++ b/src/message.py
@@ -296,7 +296,7 @@ To prevent thread spam and other natural disasters, I only respond to direct rep
 
 ---
 
-- Visit [memes.market](https://memes.market) for help, market statistics, and investor profiles.
+- Visit [meme.market](https://meme.market) for help, market statistics, and investor profiles.
 
 - Visit /r/MemeInvestor_bot for questions or suggestions about me.
 
@@ -318,7 +318,7 @@ The author of this post paid **%MEMECOIN% MemeCoins** to post this.
 
 ---
 
-- Visit [memes.market](https://memes.market) for help, market statistics, and investor profiles.
+- Visit [meme.market](https://meme.market) for help, market statistics, and investor profiles.
 
 - Visit /r/MemeInvestor_bot for questions or suggestions about me.
 


### PR DESCRIPTION
https://memes.market now redirects to https://meme.market