### PR TITLE
Filter out all empty firms

### DIFF
--- a/api/firms/firms.go
+++ b/api/firms/firms.go
@@ -35,6 +35,7 @@ func FirmsTop() func(w http.ResponseWriter, r *http.Request) {
 		query := fmt.Sprintf(`
 SELECT id, name, balance, size, execs,
 tax, rank, private, last_payout
+WHERE size > 0
 FROM Firms
 ORDER BY balance DESC 
 LIMIT %d OFFSET %d;`, per_page, per_page*page)

--- a/src/leaderboard.py
+++ b/src/leaderboard.py
@@ -145,7 +145,7 @@ def main():
         top_firms = sess.query(Firm).\
             order_by(Firm.balance.desc()).\
             limit(10).\
-            filter(Firm.balance > 0).\
+            filter(Firm.size > 0).\
             all()
 
         top_users_text = "Rank|User|Net Worth\n"

--- a/src/leaderboard.py
+++ b/src/leaderboard.py
@@ -145,6 +145,7 @@ def main():
         top_firms = sess.query(Firm).\
             order_by(Firm.balance.desc()).\
             limit(10).\
+            filter(Firm.balance > 0).\
             all()
 
         top_users_text = "Rank|User|Net Worth\n"


### PR DESCRIPTION
April's Fool Day was fun with the huge number of OP firms and stuff. To battle that, all empty firms are filtered out from API endpoints and reddit leaderboards.