### PR TITLE
Added new caddy config file. Goaccess is used in real-time (hopefully)

### DIFF
--- a/.goaccess.caddy.conf
+++ b/.goaccess.caddy.conf
@@ -1,3 +1,6 @@
-log-format %h - - [%d:%t] "%r" %s %b
-time-format %T %z
+time-format %H:%M:%S
 date-format %d/%b/%Y
+log-format %h %^[%d:%t %^] "%r" %s %b "%R" "%u"
+log-file /srv/logs/caddy.log
+output /srv/report/index.html
+real-time-html true

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
 	"./coins"
 	"./firm"
 	"./firms"
@@ -8,13 +15,7 @@ import (
 	"./investor"
 	"./investors"
 	"./summary"
-	"fmt"
 	"github.com/gorilla/mux"
-	"log"
-	"net/http"
-	"os"
-	"os/signal"
-	"time"
 )
 
 func HelloThere() func(w http.ResponseWriter, r *http.Request) {

--- a/api/coins/coins.go
+++ b/api/coins/coins.go
@@ -1,13 +1,14 @@
 package coins
 
 import (
-	"../utils"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
 	"log"
 	"net/http"
+
+	"../utils"
+	_ "github.com/go-sql-driver/mysql"
 )
 
 // Coins invested

--- a/api/firm/firm.go
+++ b/api/firm/firm.go
@@ -1,15 +1,16 @@
 package firm
 
 import (
-	"../utils"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"regexp"
+
+	"../utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gorilla/mux"
 )
 
 type firm struct {

--- a/api/firms/firms.go
+++ b/api/firms/firms.go
@@ -1,13 +1,14 @@
 package firms
 
 import (
-	"../utils"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
 	"log"
 	"net/http"
+
+	"../utils"
+	_ "github.com/go-sql-driver/mysql"
 )
 
 type firm struct {

--- a/api/investments/investments.go
+++ b/api/investments/investments.go
@@ -1,15 +1,16 @@
 package investments
 
 import (
-	"../utils"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"regexp"
+
+	"../utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gorilla/mux"
 )
 
 type investment struct {

--- a/api/investor/investor.go
+++ b/api/investor/investor.go
@@ -1,15 +1,16 @@
 package investor
 
 import (
-	"../utils"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"regexp"
+
+	"../utils"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gorilla/mux"
 )
 
 type investor struct {

--- a/api/investors/investors.go
+++ b/api/investors/investors.go
@@ -1,14 +1,15 @@
 package investors
 
 import (
-	"../utils"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
 	"log"
 	"net/http"
 	"time"
+
+	"../utils"
+	_ "github.com/go-sql-driver/mysql"
 )
 
 type investor struct {

--- a/api/summary/summary.go
+++ b/api/summary/summary.go
@@ -1,14 +1,15 @@
 package summary
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"../coins"
 	"../investments"
 	"../investors"
 	"../utils"
-	"encoding/json"
-	"fmt"
 	_ "github.com/go-sql-driver/mysql"
-	"net/http"
 )
 
 func Summary() func(w http.ResponseWriter, r *http.Request) {

--- a/docker-compose.override.yml.prod
+++ b/docker-compose.override.yml.prod
@@ -15,9 +15,19 @@ services:
           - 443:443
         volumes:
           - /data/memeinvestor/caddy/data:/root/.caddy
+	  - /data/memeinvestor/caddy/logs:/var/log
+	  - /data/memeinvestor/goaccess/html:/site/goaccess
 
     # When running in production, map the database files onto the host so they
-    # doesn't get lost when we use 'docker-compose down'.
+    # do not get lost when we use 'docker-compose down'.
     mysql:
         volumes:
           - /data/memeinvestor/mysql:/var/lib/mysql
+
+    # When running the caddy web-server, make sure that we save the logs
+    # and real time analyze them with goaccess
+    goaccess:
+        volumes:
+	  - /data/memeinvestor/caddy/logs:/srv/logs
+          - /data/memeinvestor/goaccess/data:/srv/data
+          - /data/memeinvestor/goaccess/html:/srv/report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,6 @@ services:
         ports:
           - 2015:2015
         volumes:
-          - ./caddy-logs:/var/log
           - ./goaccess/html:/site/goaccess
 
     mysql:
@@ -83,8 +82,4 @@ services:
        build:
            context: .
            dockerfile: docker/Dockerfile-goaccess
-       volumes:
-          - ./goaccess/data:/srv/data
-          - ./goaccess/html:/srv/report
-          - ./caddy-logs:/srv/logs
        entrypoint: goaccess --config-file=/etc/.goaccess.caddy.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,9 @@ services:
         command: ["./api"]
         depends_on:
           - mysql
-          - caddy
+          - http
 
-    caddy:
+    http:
         build:
             context: .
             dockerfile: docker/Dockerfile-caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,9 @@ services:
         command: ["./api"]
         depends_on:
           - mysql
-          - http
+          - caddy
 
-    http:
+    caddy:
         build:
             context: .
             dockerfile: docker/Dockerfile-caddy
@@ -68,6 +68,9 @@ services:
         restart: unless-stopped
         ports:
           - 2015:2015
+        volumes:
+          - ./caddy-logs:/var/log
+          - ./goaccess/html:/site/goaccess
 
     mysql:
         image: mariadb:10.2.15
@@ -76,3 +79,12 @@ services:
         ports:
           - 127.0.0.1:3306:3306
 
+    goaccess:
+       build:
+           context: .
+           dockerfile: docker/Dockerfile-goaccess
+       volumes:
+          - ./goaccess/data:/srv/data
+          - ./goaccess/html:/srv/report
+          - ./caddy-logs:/srv/logs
+       entrypoint: goaccess --config-file=/etc/.goaccess.caddy.conf

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,15 +1,17 @@
-memes.market {
-	redir https://meme.market
-}
-
 {$CADDY_WEB_ADDRESS} {
         cors
-	root /static
+	root /srv
 	proxy /api/ api:5000 {
 		without /api/
 		transparent
 	}
 
-	log / stdout
+	log / /var/log/caddy.log "{combined}"
 	errors stdout
+}
+
+goaccess.{$CADDY_WEB_ADDRESS} {
+        basicauth / admin password
+        root /site/goaccess
+        gzip
 }

--- a/docker/Dockerfile-caddy
+++ b/docker/Dockerfile-caddy
@@ -1,16 +1,4 @@
-FROM alpine
+FROM abiosoft/caddy
 
-RUN apk add --update --no-cache \
-    bash \
-    curl
-
-RUN curl https://getcaddy.com | bash -s personal http.cors
-
-WORKDIR /caddy
-
-COPY ./docker/Caddyfile /caddy
-COPY ./docs /static
-
-EXPOSE 80 443 2015
-
-CMD [ "caddy" ]
+COPY ./docker/Caddyfile /etc
+COPY ./docs /srv

--- a/docker/Dockerfile-goaccess
+++ b/docker/Dockerfile-goaccess
@@ -1,0 +1,4 @@
+FROM allinurl/goaccess
+
+COPY ./.goaccess.caddy.conf /etc
+RUN touch /srv/logs/caddy.log


### PR DESCRIPTION
Alright, with this update I want to have more control over the visitors or our website.

Caddy is our webserver and its logs can be used with goaccess to get a nice visualization.

I added a new subdomain goaccess.meme.market to get the current state.

But I still did not figure out how to make it real time. Because the goaccess page doesn't update on every webbrowser visit. It only updates when we restart the container.

Thanks!
