### PR TITLE
Expose amount of Associates, CFOs and COOs in API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -357,6 +357,9 @@ $ curl 'https://meme.market/api/firm/10'
  "balance": 387820,
  "size": 10,
  "execs": 3,
+ "assocs": 0,
+ "coo": 1,
+ "cfo": 1
  "tax": 10,
  "rank": 1,
  "private": false,

--- a/api/README.md
+++ b/api/README.md
@@ -359,7 +359,7 @@ $ curl 'https://meme.market/api/firm/10'
  "execs": 3,
  "assocs": 0,
  "coo": 1,
- "cfo": 1
+ "cfo": 1,
  "tax": 10,
  "rank": 1,
  "private": false,

--- a/api/firm/firm.go
+++ b/api/firm/firm.go
@@ -18,6 +18,9 @@ type firm struct {
 	Balance    int64  `json:"balance"`
 	Size       int    `json:"size"`
 	Execs      int    `json:"execs"`
+	Assocs     int    `json:"assocs"`
+	Coo        int    `json:"coo"`
+	Cfo        int    `json:"cfo"`
 	Tax        int    `json:"tax"`
 	Rank       int    `json:"rank"`
 	Private    bool   `json:"private"`
@@ -81,6 +84,9 @@ LIMIT 1;`, firm_id)
 				&temp.Balance,
 				&temp.Size,
 				&temp.Execs,
+				&temp.Assocs,
+				&temp.Coo,
+				&temp.Cfo,
 				&temp.Tax,
 				&temp.Rank,
 				&temp.Private,

--- a/api/firm/firm.go
+++ b/api/firm/firm.go
@@ -63,8 +63,8 @@ func Firm() func(w http.ResponseWriter, r *http.Request) {
 		}
 		defer conn.Close()
 		query := fmt.Sprintf(`
-SELECT id, name, balance, size, execs,
-tax, rank, private, last_payout
+SELECT id, name, balance, size, execs, assocs, 
+coo, cfo, tax, rank, private, last_payout
 FROM Firms
 WHERE id = %s
 ORDER BY balance DESC 


### PR DESCRIPTION
I'm working on a discord bot of sorts and I'd like to calculate the exact payout of firms, but this is not possible due to the API not exposing the associates amount. 

I threw in COO and CFO as well because if they're part of the Firm model surely there must be a reason for them to be an int in the DB (maybe size increase?). If there is some other purpose for this then that's OK but otherwise I'd really like to know.