### PR TITLE
Added m.imgur.com to allowed websites list

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -104,6 +104,7 @@ class CommentWorker():
     websites = [
         "imgur.com",
         "i.imgur.com",
+        "m.imgur.com",
         "reddit.com",
         "i.reddit.com",
         "v.reddit.com",


### PR DESCRIPTION
Fixes #395 with the simple whitelisting of the domain. And anyway, if you're on a desktop, it will redirect you to the desktop version.