### PR TITLE
Change bot replies to reflect new caps

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -119,7 +119,7 @@ class CommentWorker():
         r"!create",
         r"!help\s*!?(.+)?",
         r"!ignore",
-        r"!invest\s+(?:(max)|(min)|([\d,.]+)\s*(%s)?)(?:\s|$)" % "|".join(multipliers),
+        r"!invest\s+([\d,.]+)\s*(%s)?(?:\s|$)" % "|".join(multipliers),
         r"!market",
         r"!top",
         r"!version",
@@ -267,15 +267,9 @@ class CommentWorker():
         if config.PREVENT_INSIDERS:
             if comment.submission.author.name == comment.author.name:
                 return comment.reply_wrap(message.INSIDE_TRADING_ORG)
-
-        if re.match(r"max", amount, re.IGNORECASE):
-            amount = min(max(int(investor.balance / 2), 1e9), investor.balance)
-            
-        elif re.match(r"min", amount, re.IGNORECASE):
-            amount = max(int(investor.balance / 100), 100)
             
         # Allows input such as '!invest 100%' and '!invest 50%'
-        elif suffix == '%':
+        if suffix == '%':
             amount = int((investor.balance / 100) * int(amount))
         else:
             try:

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -269,7 +269,7 @@ class CommentWorker():
                 return comment.reply_wrap(message.INSIDE_TRADING_ORG)
 
         if re.match(r"max", amount, re.IGNORECASE):
-            amount = max(int(investor.balance / 2), 1e9)
+            amount = min(max(int(investor.balance / 2), 1e9), investor.balance)
             
         elif re.match(r"min", amount, re.IGNORECASE):
             amount = max(int(investor.balance / 100), 100)

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -119,7 +119,7 @@ class CommentWorker():
         r"!create",
         r"!help\s*!?(.+)?",
         r"!ignore",
-        r"!invest\s+([\d,.]+)\s*(%s)?(?:\s|$)" % "|".join(multipliers),
+        r"!invest\s+(?:(max)|(min)|([\d,.]+)\s*(%s)?)(?:\s|$)" % "|".join(multipliers),
         r"!market",
         r"!top",
         r"!version",
@@ -268,6 +268,12 @@ class CommentWorker():
             if comment.submission.author.name == comment.author.name:
                 return comment.reply_wrap(message.INSIDE_TRADING_ORG)
 
+        if re.match(r"max", amount, re.IGNORECASE):
+            amount = max(int(investor.balance / 2), 1e9)
+            
+        elif re.match(r"min", amount, re.IGNORECASE):
+            amount = max(int(investor.balance / 100), 100)
+            
         # Allows input such as '!invest 100%' and '!invest 50%'
         if suffix == '%':
             amount = int((investor.balance / 100) * int(amount))

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -170,7 +170,7 @@ class CommentWorker():
 
         # Parse the comment body for a command
         for reg in self.regexes:
-            matches = reg.fullmatch(re.sub(r"![Ii]\s+", "!invest ", comment.body.strip()))
+            matches = reg.fullmatch(comment.body.strip())
             if not matches:
                 continue
 

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -284,9 +284,9 @@ class CommentWorker():
             return comment.reply_wrap(message.modify_min_invest(minim))
 
         # Limiting investing in order to control the markets
+        maxim = int(investor.balance / 2)
         if amount / investor.balance > 0.5 and amount > 1e9:
-            return comment.\
-                reply_wrap("Investments above 1 billion MemeCoins are limited to 50% of the investor's balance.")
+            return comment.reply_wrap(message.modify_max_invest(maxim))
 
         num_inv_same_post = sess.query(Investment).\
             filter(Investment.post == comment.submission).\
@@ -305,7 +305,8 @@ class CommentWorker():
         response = comment.reply_wrap(message.modify_invest(
             amount,
             comment.submission.ups,
-            new_balance
+            new_balance,
+            num_inv_same_post
         ))
 
         # 0 upvotes is too OP, so what we do is make around 5 minumum

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -170,7 +170,7 @@ class CommentWorker():
 
         # Parse the comment body for a command
         for reg in self.regexes:
-            matches = reg.fullmatch(comment.body.strip())
+            matches = reg.fullmatch(re.sub(r"![Ii]\s+", "!invest ", comment.body.strip()))
             if not matches:
                 continue
 
@@ -291,7 +291,7 @@ class CommentWorker():
 
         # Limiting investing in order to control the markets
         maxim = int(investor.balance / 2)
-        if amount / investor.balance > 0.5 and amount > 1e9:
+        if amount > maxim and amount > 1e9:
             return comment.reply_wrap(message.modify_max_invest(maxim))
 
         num_inv_same_post = sess.query(Investment).\

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -275,7 +275,7 @@ class CommentWorker():
             amount = max(int(investor.balance / 100), 100)
             
         # Allows input such as '!invest 100%' and '!invest 50%'
-        if suffix == '%':
+        elif suffix == '%':
             amount = int((investor.balance / 100) * int(amount))
         else:
             try:

--- a/src/message.py
+++ b/src/message.py
@@ -38,15 +38,18 @@ INVEST_ORG = """
 Your investment is active. I'll evaluate your return in %TIME%and update this comment. Stay tuned!
 
 Your current balance is **%BALANCE% MemeCoins**.
+
+You have %NUM_INV% investment(s) in this post. The maximum number of investments per post is 2.
 """.replace("%TIME%", INVESTMENT_DURATION_VAR).\
     replace("%UPVOTES_WORD%", utils.upvote_string())
 
 
-def modify_invest(amount, initial_upvotes, new_balance):
+def modify_invest(amount, initial_upvotes, new_balance, num_inv_same_post):
     return INVEST_ORG.\
         replace("%AMOUNT%", format(amount, ",d")).\
         replace("%INITIAL_UPVOTES%", format(initial_upvotes, ",d")).\
-        replace("%BALANCE%", format(new_balance, ",d"))
+        replace("%BALANCE%", format(new_balance, ",d")).\
+        replace("%NUM_INV%", format(num_inv_same_post, ",d"))
 
 
 INVEST_WIN_ORG = """
@@ -269,6 +272,17 @@ The minimum possible investment is %MIN% MemeCoins (1% of your balance) or 100 m
 def modify_min_invest(minim):
     return MIN_INVEST_ORG.\
         replace("%MIN%", format(int(minim), ",d"))
+
+
+MAX_INVEST_ORG = """
+The maximum possible investment is %MAX% MemeCoins (50% of your balance) or 1,000,000,000 memecoins, whatever is higher.
+"""
+
+
+def modify_max_invest(maxim):
+    return MAX_INVEST_ORG.\
+        replace("%MAX%", format(int(maxim), ",d"))
+
 
 
 MARKET_ORG = """

--- a/src/message.py
+++ b/src/message.py
@@ -284,7 +284,6 @@ def modify_max_invest(maxim):
         replace("%MAX%", format(int(maxim), ",d"))
 
 
-
 MARKET_ORG = """
 The market has **%NUMBER%** active investments.
 


### PR DESCRIPTION
I decided to try to change the standard investment confirmation to include how many times you've invested in that post and the maximum number of times you can invest in the same post. I also tried to make the rejection message for investments above the maximum amount more informative. 

You might want to be pretty thorough in checking my code if you decide you want to use these because I have limited experience with Python