### PR TITLE
Fixing meme.market ROI calculator

### DIFF
--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -275,7 +275,7 @@ let investmentsCalculator = (function() {
    function calc(){
       let start = parseInt(document.getElementById('investment-start-score').value);
       let end = parseInt(document.getElementById('investment-end-score').value);
-      let amount = parseInt(document.getElementById('investment-amount').value);
+      let amount = parseInt(document.getElementById('investment-amount').value) ** -0.155 * 6;
       if(start>=0 && end>=0 && amount >= 100){
          //creates a spinning loader
          document.getElementById('investment-result').innerHTML =
@@ -355,8 +355,3 @@ let investmentsCalculator = (function() {
    });
    
 }());
-
-
-
-
-


### PR DESCRIPTION
For a while now the meme.market calculator has been outdated (see c9b9ed2) as a change to the formula happened a **day** after (see 6150e4d) calculating ROI based on net-worth coefficient alongside the other factors.

I've now aligned the formula again, hopefully bringing people back to meme.market once more.