### PR TITLE
Fixed CEO-COO swapping bug

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -628,7 +628,9 @@ class CommentWorker():
 
             # Swapping roles
             investor.firm_role = "coo"
+            firm.coo = investor.name
             user.firm_role = "ceo"
+            firm.ceo = user.name
 
         # Updating the flair in subreddits
         flair_role_user = ''


### PR DESCRIPTION
I forgot to modify the firm values of the DB, we're lucky this is only for API purposes and not an actual value used in production, as discussed in #416 and as I realised in #402.. 

You'll have to run the SQL script again to fix the "damage" I've kindof caused.

```sql
UPDATE firms 
LEFT JOIN investors ON firms.id = investors.firm
SET firms.ceo = investors.name 
WHERE investors.firm_role = "ceo";

UPDATE firms 
LEFT JOIN investors ON firms.id = investors.firm
SET firms.coo = investors.name 
WHERE investors.firm_role = "coo";

UPDATE firms 
LEFT JOIN investors ON firms.id = investors.firm
SET firms.cfo = investors.name 
WHERE investors.firm_role = "cfo"
```