### PR TITLE
Fixed meme.market firm leaderboard freeze

### DIFF
--- a/docs/js/firm-leaderboard.js
+++ b/docs/js/firm-leaderboard.js
@@ -4,22 +4,22 @@ import {formatToUnits, getSuffix} from './modules/dataUtils.js';
 import {seasons} from '../resources/leaderboards/seasons.js';
 
 let getLeaderboard = (function(){
-   function init(){
+   function init() {
       jsonApi.get('/firms/top?per_page=100')
       .then(d => leaderboard.update(d))
       .catch(connectionErrorToast)
    }
-   return{
+   return {
       init: init
    }
 })();
 
 
-let leaderboard = (function(){
+let leaderboard = (function() {
    let ids = {
       table: 'leaderboards-table',
       cards: {
-         prefix: ['top','left','right'],
+         prefix: ['top', 'left', 'right'],
          name: 'name',
          balance: 'balance',
          balanceSuffix: 'balance-suffix',
@@ -28,18 +28,18 @@ let leaderboard = (function(){
    }
    let cardElements = {};
 
-   function init(){
+   function init() {
       //init card elements
-      for(let prefix of ids.cards.prefix){
+      for (let prefix of ids.cards.prefix) {
          cardElements[prefix] = {
-            name: document.getElementById(prefix+'-'+ids.cards.name),
-            balance: new CountUp(prefix+'-'+ids.cards.balance,0, 0, 1),
-            balanceSuffix: document.getElementById(prefix+'-'+ids.cards.balanceSuffix),
-            profile: document.getElementById(prefix+'-'+ids.cards.profile)
+            name: document.getElementById(`${prefix}-${ids.cards.name}`),
+            balance: new CountUp(`${prefix}-${ids.cards.balance}`, 0, 0, 1),
+            balanceSuffix: document.getElementById(`${prefix}-${ids.cards.balanceSuffix}`),
+            profile: document.getElementById(`${prefix}-${ids.cards.profile}`)
          }
       }
    }
-   function update(data){
+   function update(data) {
       renderCards(data)
       renderTable(data)
    }

--- a/docs/js/firm-leaderboard.js
+++ b/docs/js/firm-leaderboard.js
@@ -5,8 +5,8 @@ import {seasons} from '../resources/leaderboards/seasons.js';
 
 let getLeaderboard = (function(){
    function init(){
-      jsonApi.get('/firms/top')
-      .then(d=> {leaderboard.update(d)})
+      jsonApi.get('/firms/top?per_page=100')
+      .then(d => leaderboard.update(d))
       .catch(connectionErrorToast)
    }
    return{

--- a/docs/js/modules/jsonApi.js
+++ b/docs/js/modules/jsonApi.js
@@ -9,12 +9,7 @@ function makeRequest (param = '', options) {
     let url = options.url+param;
     xhr.open(options.method, url);
     xhr.onload = function () {
-      if (this.status >= 200 && this.status < 300) {
-        if (!JSON.parse(xhr.response)) reject({
-          status: this.status,
-          statusText: xhr.statusText
-        })
-        
+      if (this.status >= 200 && this.status < 300 && JSON.parse(xhr.response)) {
         resolve(JSON.parse(xhr.response));
       } else {
         reject({

--- a/docs/js/modules/jsonApi.js
+++ b/docs/js/modules/jsonApi.js
@@ -10,6 +10,11 @@ function makeRequest (param = '', options) {
     xhr.open(options.method, url);
     xhr.onload = function () {
       if (this.status >= 200 && this.status < 300) {
+        if (!JSON.parse(xhr.response)) reject({
+          status: this.status,
+          statusText: xhr.statusText
+        })
+        
         resolve(JSON.parse(xhr.response));
       } else {
         reject({
@@ -35,4 +40,3 @@ export function getAll(){
 export function get(param, newOptions = options){
    return makeRequest(param, newOptions);
 }
-


### PR DESCRIPTION
As of recently, the meme.market firm leaderboard page has been freezing, and having a look in the console, it seems that the client is getting an invalid API response: ![invalid api response](https://i.imgur.com/0qvtBDH.png)

I then used the debugger and found that the client was querying `https://meme.market/api/firms/top`, and since per_page is a necessary parameter, it sent a tar.gz file that contained invalid data, which is exactly the response that the client gets. ![invalid response](https://i.imgur.com/cLE1eSY.png)

This is what happens when you don't implement a use case in-case the actual JSON parsed is invalid....