### PR TITLE
Fixed /api/investor to add firm_tax to active investments

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -206,7 +206,7 @@ $ curl 'https://meme.market/api/investor/mappum/investments?per_page=1&page=0'
 Returns an array of active investments made by that user. Request variables are supported.
 
 ``` bash
-$ curl 'https://meme.market/api/investor/DyspraxicRob/active?per_page=1&page=0'
+$ curl 'https://meme.market/api/investor/Keanu73/active?per_page=1&page=0'
 
 [
     {
@@ -222,12 +222,13 @@ $ curl 'https://meme.market/api/investor/DyspraxicRob/active?per_page=1&page=0'
      "final_upvotes": -1,
      "success": false,
      "profit": 0,
-     "firm_tax": 15
+     "firm_tax": -1
     }
 ]
 ```
 
 **NOTE:** final_upvotes is -1 because the entry does not exist and all `NULL` values in the table are replaced with -1
+**ANOTHER NOTE:** firm_tax is -1 as the firm tax is only taken into account once the investment is complete. (if user isn't in firm, will return 0)
 
 ## 5. Investors
 

--- a/api/investments/investments.go
+++ b/api/investments/investments.go
@@ -44,7 +44,7 @@ func Investments() func(w http.ResponseWriter, r *http.Request) {
 		query := fmt.Sprintf(`
 SELECT id, post, upvotes, comment, 
 name, amount, time, done, response, 
-COALESCE(final_upvotes, -1), success, profit, firm_tax
+COALESCE(final_upvotes, -1), success, profit, COALESCE(firm_tax, -1)
 FROM Investments WHERE time > %d AND time < %d
 ORDER BY time DESC 
 LIMIT %d OFFSET %d;`, from, to, per_page, per_page*page)
@@ -213,7 +213,7 @@ func InvestmentsPost() func(w http.ResponseWriter, r *http.Request) {
 		query := fmt.Sprintf(`
 SELECT id, post, upvotes, comment, 
 name, amount, time, done, response, 
-COALESCE(final_upvotes, -1), success, profit, firm_tax
+COALESCE(final_upvotes, -1), success, profit, COALESCE(firm_tax, -1)
 FROM Investments 
 WHERE time > %d AND time < %d AND post = '%s' 
 ORDER BY time DESC 

--- a/api/investor/investor.go
+++ b/api/investor/investor.go
@@ -150,7 +150,7 @@ func InvestorInvestments() func(w http.ResponseWriter, r *http.Request) {
 		query := fmt.Sprintf(`
 SELECT id, post, upvotes, comment, 
 name, amount, time, done, response, 
-COALESCE(final_upvotes, -1), success, profit, firm_tax
+COALESCE(final_upvotes, -1), success, profit, COALESCE(firm_tax, -1)
 FROM Investments 
 WHERE name = '%s' AND time > %d AND time < %d 
 ORDER BY time DESC 

--- a/api/investor/investor.go
+++ b/api/investor/investor.go
@@ -39,6 +39,7 @@ type investment struct {
 	Final_upvotes int    `json:"final_upvotes"`
 	Success       bool   `json:"success"`
 	Profit        int64  `json:"profit"`
+	Firm_tax      int64  `json:"firm_tax"`
 }
 
 func Investor() func(w http.ResponseWriter, r *http.Request) {
@@ -149,7 +150,7 @@ func InvestorInvestments() func(w http.ResponseWriter, r *http.Request) {
 		query := fmt.Sprintf(`
 SELECT id, post, upvotes, comment, 
 name, amount, time, done, response, 
-COALESCE(final_upvotes, -1), success, profit 
+COALESCE(final_upvotes, -1), success, profit, firm_tax
 FROM Investments 
 WHERE name = '%s' AND time > %d AND time < %d 
 ORDER BY time DESC 
@@ -176,6 +177,7 @@ LIMIT %d OFFSET %d`, name, from, to, per_page, per_page*page)
 				&temp.Final_upvotes,
 				&temp.Success,
 				&temp.Profit,
+				&temp.Firm_tax
 			)
 			if err != nil {
 				log.Print(err)
@@ -213,7 +215,7 @@ func InvestorInvestmentsActive() func(w http.ResponseWriter, r *http.Request) {
 		query := fmt.Sprintf(`
 SELECT id, post, upvotes, comment, 
 name, amount, time, done, response, 
-COALESCE(final_upvotes, -1), success, profit 
+COALESCE(final_upvotes, -1), success, profit, COALESCE(firm_tax, -1)
 FROM Investments 
 WHERE name = '%s' AND done = 0 AND time > %d AND time < %d 
 ORDER BY time DESC 
@@ -240,6 +242,7 @@ LIMIT %d OFFSET %d`, name, from, to, per_page, per_page*page)
 				&temp.Final_upvotes,
 				&temp.Success,
 				&temp.Profit,
+				&temp.Firm_tax
 			)
 			if err != nil {
 				log.Print(err)


### PR DESCRIPTION
I noticed that investor.go didn't include my changes, and to add my changes over to it I had to copy the type struct field AND the SQL scanning thingies. I've suggested something to make life easier in #420.