### PR TITLE
Improve the website style

### DIFF
--- a/docs/css/user.css
+++ b/docs/css/user.css
@@ -141,6 +141,10 @@ td span .material-icons{
     vertical-align: top;
 }
 
+.invest-values {
+  text-align: right;
+}
+
 /* --[graph row]-- */
 .custom-select{
   width:200px;

--- a/docs/js/firm-leaderboard.js
+++ b/docs/js/firm-leaderboard.js
@@ -51,7 +51,7 @@ let leaderboard = (function() {
          html += `<tr>
                      <td>#${i+1}</td>
                      <td><a href="./firm.html?firm=${firm.id}">${firm.name} ${badge}</a></td>
-                     <td title="${commafy(firm.balance)}">${formatToUnits(firm.balance)}</td>
+                     <td title="${commafy(firm.balance)} M&cent;">${formatToUnits(firm.balance)}</td>
                      <td>${firm.rank}</td>
                      <td>${firm.size}</td>
                   </tr>`

--- a/docs/js/firm-leaderboard.js
+++ b/docs/js/firm-leaderboard.js
@@ -1,6 +1,6 @@
 import {connectionErrorToast} from './modules/uiElements.js';
 import * as jsonApi from './modules/jsonApi.js';
-import {formatToUnits, getSuffix} from './modules/dataUtils.js';
+import {formatToUnits, getSuffix, commafy} from './modules/dataUtils.js';
 import {seasons} from '../resources/leaderboards/seasons.js';
 
 let getLeaderboard = (function(){
@@ -51,7 +51,7 @@ let leaderboard = (function() {
          html += `<tr>
                      <td>#${i+1}</td>
                      <td><a href="./firm.html?firm=${firm.id}">${firm.name} ${badge}</a></td>
-                     <td>${formatToUnits(firm.balance)}</td>
+                     <td title="${commafy(firm.balance)}">${formatToUnits(firm.balance)}</td>
                      <td>${firm.rank}</td>
                      <td>${firm.size}</td>
                   </tr>`

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -1,6 +1,6 @@
 import {connectionErrorToast} from './modules/uiElements.js';
 import * as jsonApi from './modules/jsonApi.js';
-import {formatToUnits, iterateDays} from './modules/dataUtils.js';
+import {formatToUnits, commafy, iterateDays} from './modules/dataUtils.js';
 import {Scheduler} from './modules/scheduler.js';
 
 let ticker = (function(){
@@ -210,7 +210,7 @@ let leaderboard = (function(){
              //broke badge
              let badge = top[i].broke>0? '<span class="red bankrupt-badge white-text">'+top[i].broke+'</span>':"";
              html += '<tr><td><a href="./user.html?account='+top[i].name+'">'+top[i].name+"</a>"+badge+"</td>"+
-                         "<td>"+formatToUnits(top[i].networth)+"</td>"+
+                         '<td title="'+commafy(top[i].networth)+' M&cent;">'+formatToUnits(top[i].networth)+"</td>"+
                          "<td>"+top[i].completed+"</td></tr>"
           }
       tb.innerHTML = html

--- a/docs/js/leaderboards.js
+++ b/docs/js/leaderboards.js
@@ -1,6 +1,6 @@
 import {connectionErrorToast} from './modules/uiElements.js';
 import * as jsonApi from './modules/jsonApi.js';
-import {formatToUnits, getSuffix} from './modules/dataUtils.js';
+import {formatToUnits, getSuffix, commafy} from './modules/dataUtils.js';
 import {seasons} from '../resources/leaderboards/seasons.js';
 
 let getSeason = (function(){
@@ -96,7 +96,7 @@ let leaderboard = (function(){
          html += `<tr>
                      <td>#${i+1}</td>
                      <td><a href="./user.html?account=${user.name}">${user.name} ${badge}</a></td>
-                     <td>${formatToUnits(user.networth)}</td>
+                     <td title="${commafy(user.networth)} M&cent;">${formatToUnits(user.networth)}</td>
                      <td>${user.completed}</td>
                   </tr>`
       }

--- a/docs/js/modules/dataUtils.js
+++ b/docs/js/modules/dataUtils.js
@@ -15,6 +15,21 @@ export function getSuffix(val){
    }  
 }
 
+export function commafy(val) {
+   if (Number.isSafeInteger(val)) {
+      let s = Math.abs(val).toFixed(0); // toString might use the large-number format when it's not needed
+      for (let i = s.length - 3; i > 0; i -= 3)
+         s = s.substring(0, i) + ',' + s.substring(i);
+      if (val < 0)
+         s = '-' + s;
+      return s;
+   } else {
+      // switch to scientific notation
+      let magnitude = Math.floor(Math.log10(Math.abs(val)));
+      return val / Math.pow(10, magnitude) + '&times;10' + magnitude.replace(/./g, m => '&' + ['#8304', 'sup1', 'sup2', 'sup3', '#8308', '#8309', '#8310', '#8311', '#8312', '#8313'][m] + ';';
+   }
+}
+
 export function iterateDays(days, callback) {
     let to = new Date();
     to.setHours(0);

--- a/docs/js/modules/dataUtils.js
+++ b/docs/js/modules/dataUtils.js
@@ -26,7 +26,7 @@ export function commafy(val) {
    } else {
       // switch to scientific notation
       let magnitude = Math.floor(Math.log10(Math.abs(val)));
-      return val / Math.pow(10, magnitude) + '&times;10' + magnitude.replace(/./g, m => '&' + ['#8304', 'sup1', 'sup2', 'sup3', '#8308', '#8309', '#8310', '#8311', '#8312', '#8313'][m] + ';';
+      return val / Math.pow(10, magnitude) + '&times;10' + magnitude.replace(/./g, m => '&' + ['#8304', 'sup1', 'sup2', 'sup3', '#8308', '#8309', '#8310', '#8311', '#8312', '#8313'][m] + ';');
    }
 }
 

--- a/docs/js/modules/dataUtils.js
+++ b/docs/js/modules/dataUtils.js
@@ -5,14 +5,13 @@ export function formatToUnits(val) {
 
 export function getSuffix(val){
    let number = parseInt(val);
-   let abbrev = ['', 'K', 'M', 'B', 'T', 'q', 'Q', 's', 'S'];
+   let abbrev = ['', 'k', 'M', 'B', 'T', 'q', 'Q', 's', 'S'];
    let unrangifiedOrder = Math.floor(Math.log10(Math.abs(number)) / 3);
-   let order = Math.max(0, Math.min(unrangifiedOrder, abbrev.length -1 ));
-   let suffix = abbrev[order];
-   let precision = suffix ? 1 : 0;
+   let order = Math.max(0, Math.min(unrangifiedOrder, abbrev.length - 1));
+   let toDisplay = number / Math.pow(10, order * 3);
    return {
-      val: (number / Math.pow(10, order * 3)).toFixed(precision),
-      suffix: suffix
+      val: unrangifiedOrder > 0 && unrangifiedOrder < abbrev.length ? toDisplay.toPrecision(3) : toDisplay.toFixed(0),
+      suffix: abbrev[order]
    }  
 }
 

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -1,7 +1,7 @@
 import {connectionErrorToast} from './modules/uiElements.js';
 import * as jsonApi from './modules/jsonApi.js';
 import {Scheduler} from './modules/scheduler.js';
-import {formatToUnits} from './modules/dataUtils.js';
+import {formatToUnits, commafy} from './modules/dataUtils.js';
 import {getFileName, getDescription} from './modules/badges.js';
 
 var getUser = (function(){
@@ -414,14 +414,21 @@ let investments = (function(){
          <tr>
             <td><a href="https://redd.it/${inv.post}">${inv.post}</a></td>
             <td><span class="grey-text">${time}<br>${date}</span></td>
-            <td>${formatToUnits(inv.amount)} M¢<br>${formatToUnits(inv.upvotes)} &uarr;</td>
+            <td>
+                <span title="${commafy(inv.amount)} MemeCoins">${formatToUnits(inv.amount)} M&cent;</span>
+                <br>
+                <span title="${commafy(inv.upvotes)} upvotes">${formatToUnits(inv.upvotes)} &uarr;</span>
+            </td>
             <td>`
          if(inv.done){
             let color = inv.success? 'green-text' : 'red-text text-lighten-1'
             let sign = inv.success? '<i class="material-icons">arrow_drop_up</i>' : '<i class="material-icons">arrow_drop_down</i>'
             let profit = sign+formatToUnits(Math.abs(inv.profit))
             let finalUpvotes = inv.final_upvotes? formatToUnits(inv.final_upvotes) : '--';
-            html += `<span class="${color}">${profit} M¢</span><br>${finalUpvotes} &uarr;`
+            html += `
+            <span class="${color}" title="${commafy(inv.profit)} MemeCoins">${profit} M&cent;</span>
+            <br>
+            <span title="${commafy(inv.final_upvotes)} upvotes">${finalUpvotes} &uarr;</span>`
          }else{
             let currentTime = new Date();
             //14400000 == 4h

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -414,14 +414,14 @@ let investments = (function(){
          <tr>
             <td><a href="https://redd.it/${inv.post}">${inv.post}</a></td>
             <td><span class="grey-text">${time}<br>${date}</span></td>
-            <td>${formatToUnits(inv.amount)} M¢<br>${formatToUnits(inv.upvotes)} upvotes</td>
+            <td>${formatToUnits(inv.amount)} M¢<br>${formatToUnits(inv.upvotes)} &uarr;</td>
             <td>`
          if(inv.done){
             let color = inv.success? 'green-text' : 'red-text text-lighten-1'
             let sign = inv.success? '<i class="material-icons">arrow_drop_up</i>' : '<i class="material-icons">arrow_drop_down</i>'
             let profit = sign+formatToUnits(Math.abs(inv.profit))
             let finalUpvotes = inv.final_upvotes? formatToUnits(inv.final_upvotes) : '--';
-            html += `<span class="${color}">${profit} M¢</span><br>${finalUpvotes} upvotes`
+            html += `<span class="${color}">${profit} M¢</span><br>${finalUpvotes} &uarr;`
          }else{
             let currentTime = new Date();
             //14400000 == 4h
@@ -433,7 +433,7 @@ let investments = (function(){
                let timeLeftString = hoursLeftString+':'+minutesLeftString;
                html += `<span><i class="material-icons">access_time</i> ${timeLeftString} left</span>`
             }else{
-               html += '<span><i class="material-icons">layers</i> processsing..</span>'
+               html += '<span><i class="material-icons">layers</i> processing&hellip;</span>'
             }
          }
          html += '</td></tr>'

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -415,21 +415,14 @@ let investments = (function(){
          <tr>
             <td><a href="https://redd.it/${inv.post}">${inv.post}</a></td>
             <td><span class="grey-text">${time}<br>${date}</span></td>
-            <td class="invest-values">
-                <span title="${commafy(inv.amount)} MemeCoins">${formatToUnits(inv.amount)} M&cent;</span>
-                <br>
-                <span title="${commafy(inv.upvotes)} upvotes">${formatToUnits(inv.upvotes)} &uarr;</span>
-            </td>
+            <td class="invest-values"><span title="${commafy(inv.amount)} MemeCoins">${formatToUnits(inv.amount)} M&cent;</span><br><span title="${commafy(inv.upvotes)} upvotes">${formatToUnits(inv.upvotes)} &uarr;</span></td>
             <td class="invest-values">`
          if(inv.done){
             let color = inv.success? 'green-text' : 'red-text text-lighten-1'
             let sign = inv.success? '<i class="material-icons">arrow_drop_up</i>' : '<i class="material-icons">arrow_drop_down</i>'
             let profit = sign+formatToUnits(Math.abs(inv.profit))
             let finalUpvotes = inv.final_upvotes? formatToUnits(inv.final_upvotes) : '--';
-            html += `
-            <span class="${color}" title="${commafy(inv.profit)} MemeCoins">${profit} M&cent;</span>
-            <br>
-            <span title="${commafy(inv.final_upvotes)} upvotes">${finalUpvotes} &uarr;</span>`
+            html += `<span class="${color}" title="${commafy(inv.profit)} MemeCoins">${profit} M&cent;</span><br><span title="${commafy(inv.final_upvotes)} upvotes">${finalUpvotes} &uarr;</span>`
          }else{
             let currentTime = new Date();
             //14400000 == 4h

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -262,6 +262,7 @@ let investments = (function(){
       document.getElementById(ids.clearFilters).addEventListener('click',clearFilters);
       document.getElementById(ids.page.previous).addEventListener('click',previous);
       document.getElementById(ids.page.next).addEventListener('click',next);
+      setInterval(60000, updateTable);
    }
    //initialize the table for a specific user
    function setUser(userName,amount){

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -401,8 +401,8 @@ let investments = (function(){
         <tr>
             <th>post</th>
             <th>date</th>
-            <th>in</th>
-            <th>result</th>
+            <th class="invest-values">in</th>
+            <th class="invest-values">result</th>
         </tr>
       </thead>
       <tbody>
@@ -415,12 +415,12 @@ let investments = (function(){
          <tr>
             <td><a href="https://redd.it/${inv.post}">${inv.post}</a></td>
             <td><span class="grey-text">${time}<br>${date}</span></td>
-            <td>
+            <td class="invest-values">
                 <span title="${commafy(inv.amount)} MemeCoins">${formatToUnits(inv.amount)} M&cent;</span>
                 <br>
                 <span title="${commafy(inv.upvotes)} upvotes">${formatToUnits(inv.upvotes)} &uarr;</span>
             </td>
-            <td>`
+            <td class="invest-values">`
          if(inv.done){
             let color = inv.success? 'green-text' : 'red-text text-lighten-1'
             let sign = inv.success? '<i class="material-icons">arrow_drop_up</i>' : '<i class="material-icons">arrow_drop_down</i>'


### PR DESCRIPTION
This pull request makes a number of stylistic changes to the meme.market website:

  - Upvote counts and MemeCoin amounts will show the exact value on hover using the `title` attribute. An exception is when the exact value is too large for JavaScript to handle.
  - Upvote counts will use an up arrow icon.
  - `formatToUnits` will use exactly 3 digits of precision unless the value is less than 3 digits or larger than the largest suffix can handle.
  - `formatToUnits` will use the proper capitalization for the "thousand" prefix (`k` instead of `K`).
  - Investment tables will automatically update every 60 seconds.
  - So that the up arrow icons don't look as off, the initial/final investment amounts and upvote counts will be right-aligned.

Screenshots of modified website (somewhat limited in that the mouse isn't shown):

![Hover text demo](https://user-images.githubusercontent.com/29645476/59208536-dbb13d00-8b6e-11e9-8906-a7184fa6cdc5.png)

![User page](https://user-images.githubusercontent.com/29645476/59208671-2cc13100-8b6f-11e9-9b79-431643091b1c.png)