### PR TITLE
Fix vote count leaks

### DIFF
--- a/api/investor/investor.go
+++ b/api/investor/investor.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"time"
 
 	"../utils"
 	_ "github.com/go-sql-driver/mysql"
@@ -148,7 +149,7 @@ func InvestorInvestments() func(w http.ResponseWriter, r *http.Request) {
 		defer conn.Close()
 		// Making it networth
 		query := fmt.Sprintf(`
-SELECT id, post, upvotes, comment, 
+SELECT id, post, reveal_time, upvotes, comment, 
 name, amount, time, done, response, 
 COALESCE(final_upvotes, -1), success, profit, COALESCE(firm_tax, -1)
 FROM Investments 
@@ -163,10 +164,13 @@ LIMIT %d OFFSET %d`, name, from, to, per_page, per_page*page)
 		defer rows.Close()
 		wrapper := make([]investment, 0, per_page)
 		temp := investment{}
+		ctime := time.Now()
 		for rows.Next() {
+			var rtime int
 			err := rows.Scan(
 				&temp.Id,
 				&temp.Post,
+				&rtime,
 				&temp.Upvotes,
 				&temp.Comment,
 				&temp.Name,
@@ -182,6 +186,9 @@ LIMIT %d OFFSET %d`, name, from, to, per_page, per_page*page)
 			if err != nil {
 				log.Print(err)
 				return
+			}
+			if rtime != nil && rtime > ctime {
+				temp.Upvotes = nil
 			}
 			wrapper = append(wrapper, temp)
 		}
@@ -213,7 +220,7 @@ func InvestorInvestmentsActive() func(w http.ResponseWriter, r *http.Request) {
 		}
 		defer conn.Close()
 		query := fmt.Sprintf(`
-SELECT id, post, upvotes, comment, 
+SELECT id, post, reveal_time, upvotes, comment, 
 name, amount, time, done, response, 
 COALESCE(final_upvotes, -1), success, profit, COALESCE(firm_tax, -1)
 FROM Investments 
@@ -228,10 +235,13 @@ LIMIT %d OFFSET %d`, name, from, to, per_page, per_page*page)
 		defer rows.Close()
 		wrapper := make([]investment, 0, per_page)
 		temp := investment{}
+		ctime := time.Now()
 		for rows.Next() {
+			var rtime int
 			err := rows.Scan(
 				&temp.Id,
 				&temp.Post,
+				&rtime,
 				&temp.Upvotes,
 				&temp.Comment,
 				&temp.Name,
@@ -247,6 +257,9 @@ LIMIT %d OFFSET %d`, name, from, to, per_page, per_page*page)
 			if err != nil {
 				log.Print(err)
 				return
+			}
+			if rtime != nil && rtime > ctime {
+				temp.Upvotes = nil
 			}
 			wrapper = append(wrapper, temp)
 		}

--- a/docs/js/user.js
+++ b/docs/js/user.js
@@ -414,7 +414,7 @@ let investments = (function(){
          <tr>
             <td><a href="https://redd.it/${inv.post}">${inv.post}</a></td>
             <td><span class="grey-text">${time}<br>${date}</span></td>
-            <td>${formatToUnits(inv.amount)} M¢<br>${formatToUnits(inv.upvotes)} upvotes</td>
+            <td>${formatToUnits(inv.amount)} M¢<br>${inv.upvotes == null ? '???' : formatToUnits(inv.upvotes)} upvotes</td>
             <td>`
          if(inv.done){
             let color = inv.success? 'green-text' : 'red-text text-lighten-1'

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -290,10 +290,12 @@ class CommentWorker():
         if new_balance < 0:
             return comment.reply_wrap(message.modify_insuff(investor.balance))
 
+        reveal_time = comment.submission.created_utc + 7200;
+
         # Sending a confirmation
         response = comment.reply_wrap(message.modify_invest(
             amount,
-            None if time.time() < comment.submission.created_utc + 7200 else comment.submission.ups,
+            None if time.time() < vote_reveal_time else comment.submission.ups,
             new_balance
         ))
 
@@ -304,6 +306,7 @@ class CommentWorker():
 
         sess.add(Investment(
             post=comment.submission,
+            reveal_time=int(reveal_time),
             upvotes=upvotes_now,
             comment=comment,
             name=author,

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -293,7 +293,7 @@ class CommentWorker():
         # Sending a confirmation
         response = comment.reply_wrap(message.modify_invest(
             amount,
-            comment.submission.ups,
+            None if time.time() < comment.submission.created_utc + 7200 else comment.submission.ups,
             new_balance
         ))
 

--- a/src/message.py
+++ b/src/message.py
@@ -45,7 +45,7 @@ Your current balance is **%BALANCE% MemeCoins**.
 def modify_invest(amount, initial_upvotes, new_balance):
     return INVEST_ORG.\
         replace("%AMOUNT%", format(amount, ",d")).\
-        replace("%INITIAL_UPVOTES%", format(initial_upvotes, ",d")).\
+        replace("%INITIAL_UPVOTES%", "???" if initial_upvotes is None else format(initial_upvotes, ",d")).\
         replace("%BALANCE%", format(new_balance, ",d"))
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -36,6 +36,7 @@ class Investment(Base):
 
     id = Column(Integer, primary_key=True)
     post = Column(String(11), nullable=False)
+    reveal_time = Column(Integer, nullable=True)
     upvotes = Column(Integer, default=0)
     comment = Column(String(11), nullable=False, unique=True)
     name = Column(String(20), nullable=False, index=True)


### PR DESCRIPTION
Even with the vote count hidden, it’s possible to find the exact vote count of a post by either a) looking at the initial vote counts on recent investments on the post, or b) making a small "test" investment on the post and checking its initial vote count on Reddit or memes.market. This pull request fixes this minor exploit, by concealing initial vote counts until the post's score becomes visible to all users. Due to the way that the concealment was implemented, a `reveal_time` column will need to be added to the `Investments` table in the database if/when the changes are moved to production.

As this is currently untested due to a lack of suitable SQL software, I am posting this as a draft PR.