### PR TITLE
Fixed possible cause for bug with CFO value

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -722,7 +722,7 @@ class CommentWorker():
                 return comment.reply_wrap(message.not_ceo_org)
 
             # If the firm already has a CFO, the user will be demoted to Executive
-            if firm.cfo is not None:
+            if firm.cfo != '':
                 max_execs = max_execs_for_rank(firm.rank)
                 if firm.execs >= max_execs:
                     return comment.reply_wrap(message.modify_demote_execs_full(firm))


### PR DESCRIPTION
As I looked at my firm's API object, I saw that the CEO and CFO are the exact same person. https://meme.market/api/firm/125

I found that you missed one in your previous fix (fe71d5447ade8624e5b33b2a779fbf17e30fe563) so hopefully this is the cause for the bug. As per usual, you'll have to run the SQL script (again).

```sql
UPDATE Firms INNER JOIN Investors ON Investors.firm = Firms.id AND Investors.firm_role = "ceo" SET Firms.ceo = Investors.name
UPDATE Firms INNER JOIN Investors ON Investors.firm = Firms.id AND Investors.firm_role = "coo" SET Firms.coo = Investors.name
UPDATE Firms INNER JOIN Investors ON Investors.firm = Firms.id AND Investors.firm_role = "cfo" SET Firms.cfo = Investors.name
```