### PR TITLE
Added NetWorth parameter to firm members and linted API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -45,8 +45,8 @@ func main() {
 	r.HandleFunc("/investors/last24", investors.InvestorsLast24()).Methods("GET")
 	r.HandleFunc("/firms/top", firms.FirmsTop()).Methods("GET")
 	r.HandleFunc("/firm/{id}", firm.Firm()).Methods("GET")
-	r.HandleFunc("/firm/{id}/members", firm.FirmMembers()).Methods("GET")
-	r.HandleFunc("/firm/{id}/members/top", firm.FirmMembersTop()).Methods("GET")
+	r.HandleFunc("/firm/{id}/members", firm.Members()).Methods("GET")
+	r.HandleFunc("/firm/{id}/members/top", firm.MembersTop()).Methods("GET")
 	srv := &http.Server{
 		Handler: r,
 		Addr:    ":5000",


### PR DESCRIPTION
I just replaced the firm member SQL query with the one used for net worth, and I also linted the API a bit.
I did this so you don't just have to use /firm/members/top and could theoretically just sort it on the client's end.