### PR TITLE
Change number of results in firm and leaderboard pages

### DIFF
--- a/docs/js/firm-leaderboard.js
+++ b/docs/js/firm-leaderboard.js
@@ -5,7 +5,7 @@ import {seasons} from '../resources/leaderboards/seasons.js';
 
 let getLeaderboard = (function(){
    function init() {
-      jsonApi.get('/firms/top?per_page=100')
+      jsonApi.get('/firms/top?per_page=50')
       .then(d => leaderboard.update(d))
       .catch(connectionErrorToast)
    }

--- a/docs/resources/leaderboards/seasons.js
+++ b/docs/resources/leaderboards/seasons.js
@@ -1,4 +1,4 @@
 export const seasons = [
    {name:'beta season', id:'beta', dataUrl:'./resources/leaderboards/beta.json'},
-   {name:'season 1', id:'1', dataUrl:'https://meme.market/api/investors/top?per_page=50'},
+   {name:'season 1', id:'1', dataUrl:'https://meme.market/api/investors/top?per_page=100'},
 ]


### PR DESCRIPTION
With the amount of investors in the economy it makes more sense to
show the top 100. Inversely, the economy is concentrated on the top
firms; lower the amount of firms shown in the firm-leaderboard.

Just a proposal but I've mentioned this to a few very active investors and they all agreed this would be better. Those in the top 50 to 100 also deserve recognition.