### PR TITLE
Fixing some silly mistakes with the cosmetic firm officer values

### DIFF
--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -605,11 +605,11 @@ class CommentWorker():
 
                 user.firm_role = "coo"
                 firm.execs -= 1
-                firm.coo = investor.name
+                firm.coo = user.name
             else:
                 user.firm_role = "cfo"
                 firm.execs -= 1
-                firm.cfo = investor.name
+                firm.cfo = user.name
 
         elif user_role == "cfo":
             if investor.firm_role != "ceo":
@@ -620,7 +620,7 @@ class CommentWorker():
 
             user.firm_role = "coo"
             firm.cfo = ''
-            firm.coo = investor.name
+            firm.coo = user.name
 
         elif user_role == "coo":
             if investor.firm_role != "ceo":
@@ -728,12 +728,12 @@ class CommentWorker():
                     return comment.reply_wrap(message.modify_demote_execs_full(firm))
 
                 user.firm_role = "exec"
-                firm.cfo = ''
+                firm.coo = ''
                 firm.execs += 1
             else:
                 user.firm_role = "cfo"
                 firm.coo = ''
-                firm.cfo = investor.name
+                firm.cfo = user.name
 
         # Updating the flair in subreddits
         flair_role_user = ''

--- a/src/comment_worker.py
+++ b/src/comment_worker.py
@@ -599,8 +599,8 @@ class CommentWorker():
                 return comment.reply_wrap(message.not_ceo_org)
 
             # If the firm already has a CFO, the user will be promoted to COO
-            if firm.cfo != '':
-                if firm.coo != '':
+            if firm.cfo != '' and firm.cfo != 0:
+                if firm.coo != '' and firm.coo != 0:
                     return comment.reply_wrap(message.promote_coo_full_org)
 
                 user.firm_role = "coo"
@@ -615,7 +615,7 @@ class CommentWorker():
             if investor.firm_role != "ceo":
                 return comment.reply_wrap(message.not_ceo_org)
 
-            if firm.coo != '':
+            if firm.coo != '' and firm.coo != 0:
                 return comment.reply_wrap(message.promote_coo_full_org)
 
             user.firm_role = "coo"
@@ -722,13 +722,13 @@ class CommentWorker():
                 return comment.reply_wrap(message.not_ceo_org)
 
             # If the firm already has a CFO, the user will be demoted to Executive
-            if firm.cfo != '':
+            if firm.cfo != '' and firm.cfo != 0:
                 max_execs = max_execs_for_rank(firm.rank)
                 if firm.execs >= max_execs:
                     return comment.reply_wrap(message.modify_demote_execs_full(firm))
 
                 user.firm_role = "exec"
-                firm.coo = ''
+                firm.cfo = ''
                 firm.execs += 1
             else:
                 user.firm_role = "cfo"


### PR DESCRIPTION
Alright, so now I see a couple of mistakes in my code which may have lead to craziness like this: `{"id":158,"name":"EMPYREAN","balance":787098244161521,"size":79,"execs":11,"assocs":20,"ceo":"**JonathanTheZero**","coo":"**JonathanTheZero**","cfo":"**JonathanTheZero**","tax":5,"rank":4,"private":true,"last_payout":1562364233}`

Including accidentally using the person who ran the command's name to set as the firm's CFO or COO value **INSTEAD** of the actual target....

I also added a check to check if the value is still 0 (remember, when we first ran the SQL script values that were 0 were never changed so we need to make sure they are supported too).